### PR TITLE
Add SMB dialect 2.1 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ How to set up a `renterd` node is described here: [https://github.com/SiaFoundat
 * The SMB port 445 needs to be open on the machine where the server is running.
 
 ## Limitations
-* At this moment, only the SMB dialect 2.0.2 is supported. Newer dialects will potentially be supported in the future.
+* At this moment, only the SMB dialects 2.0.2 and 2.1 are supported. Newer dialects will potentially be supported in the future.
 * Guest or anonymous access is not supported.
 
 ## Installing PostgreSQL
@@ -134,7 +134,7 @@ Please note: Windows 2000/NT/XP and earlier are not supported. The earliest supp
 ### MacOS
 1. In the `Finder` menu choose `Go -> Connect to Server...`.
 2. Enter `smb://<SERVER_NET_ADDRESS>/<SHARE_NAME>` as the server name, then click `Connect`.
-3. In the next popup window, choose `Connect As: Registered User` and enter the user credentials (matching one of the registered accounts), then click `Connect`.
+3. In the next popup window, choose `Connect As: Registered User` and enter the user credentials (matching one of the registered accounts, in form `<WORKGROUP>`\\`<USERNAME>`), then click `Connect`.
 
 ### Ubuntu GUI
 1. In the file manager (e.g. Nautilus), navigate to `Other Locations`, enter `smb://<SERVER_NET_ADDRESS>/<SHARE_NAME>` in the `Enter server address` field, then click `Connect`.
@@ -155,12 +155,30 @@ sudo chown $USER:$USER /mnt/sia
 ```
 3. Mount the share with
 ```
-sudo mount -t cifs //<SERVER_NET_ADDRESS>/<SHARE_NAME> /mnt/sia -o username=<USERNAME>,password=<PASSWORD>,vers=2.0
+sudo mount -t cifs //<SERVER_NET_ADDRESS>/<SHARE_NAME> /mnt/sia -o username=<USERNAME>,workgroup=<WORKGROUP>,password=<PASSWORD>,vers=2.0
 ```
 4. To unmount, type
 ```
 sudo umount /mnt/sia
 ```
+
+## Proposed Testing Scenario
+1. Connect to the share
+2. Copy a file to the share root
+3. Rename the file in the share root
+4. Copy that file from the share root
+5. Make a directory in the share root
+6. Copy a file to that directory
+7. Rename the file in that directory
+8. Copy that file from that directory
+9. Rename that directory
+10. Delete that directory
+11. Delete the file in the root directory
+12. Copy a directory containing files to the share root
+13. Copy that directory from the share root
+14. Disconnect from the share
+
+Please note: on Windows, there may be issues with reads or writes when OneDrive is enabled and the file is not available locally.
 
 ## Bug Reporting
 Please do not hesitate to open an issue if you discover any bugs.

--- a/conn.go
+++ b/conn.go
@@ -203,11 +203,12 @@ func (c *connection) processRequest(req *smb2.Request) (smb2.GenericResponse, *s
 
 		// Respond with an SMB2_NEGOTIATE response.
 		dialect := nr.MaxCommonDialect()
+		c.negotiateDialect = dialect
 		switch dialect {
 		case smb2.SMB_DIALECT_202:
-			c.negotiateDialect = dialect
 			c.dialect = "2.0.2"
 		case smb2.SMB_DIALECT_MULTICREDIT:
+			c.dialect = "2.?.?"
 			c.supportsMultiCredit = true
 		}
 		c.grantCredits(nr.Header().MessageID(), 1) // Grant just one credit

--- a/conn.go
+++ b/conn.go
@@ -395,6 +395,9 @@ func (c *connection) processRequest(req *smb2.Request) (smb2.GenericResponse, *s
 			if errors.Is(err, errAccessDenied) {
 				resp := smb2.NewErrorResponse(tcr, smb2.STATUS_ACCESS_DENIED, nil)
 				return resp, ss, nil
+			} else if errors.Is(err, errNoShare) {
+				resp := smb2.NewErrorResponse(tcr, smb2.STATUS_SHARE_UNAVAILABLE, nil)
+				return resp, ss, nil
 			} else {
 				resp := smb2.NewErrorResponse(tcr, smb2.STATUS_INVALID_PARAMETER, nil)
 				return resp, ss, nil

--- a/conn.go
+++ b/conn.go
@@ -203,12 +203,11 @@ func (c *connection) processRequest(req *smb2.Request) (smb2.GenericResponse, *s
 
 		// Respond with an SMB2_NEGOTIATE response.
 		dialect := nr.MaxCommonDialect()
-		c.negotiateDialect = dialect
 		switch dialect {
 		case smb2.SMB_DIALECT_202:
+			c.negotiateDialect = dialect
 			c.dialect = "2.0.2"
 		case smb2.SMB_DIALECT_MULTICREDIT:
-			c.dialect = "2.?.?"
 			c.supportsMultiCredit = true
 		}
 		c.grantCredits(nr.Header().MessageID(), 1) // Grant just one credit

--- a/conn.go
+++ b/conn.go
@@ -1074,6 +1074,13 @@ func (c *connection) processRequest(req *smb2.Request) (smb2.GenericResponse, *s
 			id = op.id()
 		}
 
+		if c.dialect == "2.1" || c.dialect == "3.0" {
+			if wr.Flags()&smb2.WRITEFLAG_WRITE_THROUGH > 0 && op.createOptions&smb2.FILE_NO_INTERMEDIATE_BUFFERING == 0 {
+				resp := smb2.NewErrorResponse(wr, smb2.STATUS_INVALID_PARAMETER, nil)
+				return resp, ss, nil
+			}
+		}
+
 		req.SetOpenID(id)
 		if op.fileName != "" && op.fileName[0] == '.' { // Ignore SMB2_WRITE requests to any hidden file (whose name starts with a dot)
 			resp := &smb2.WriteResponse{}

--- a/conn.go
+++ b/conn.go
@@ -187,10 +187,11 @@ func (c *connection) processRequest(req *smb2.Request) (smb2.GenericResponse, *s
 
 		// Respond with an SMB2_NEGOTIATE response.
 		dialect := nr.MaxCommonDialect()
-		if dialect == smb2.SMB_DIALECT_202 {
+		switch dialect {
+		case smb2.SMB_DIALECT_202:
 			c.negotiateDialect = dialect
 			c.dialect = "2.0.2"
-		} else if dialect == smb2.SMB_DIALECT_MULTICREDIT {
+		case smb2.SMB_DIALECT_MULTICREDIT:
 			c.supportsMultiCredit = true
 		}
 

--- a/conn.go
+++ b/conn.go
@@ -392,12 +392,11 @@ func (c *connection) processRequest(req *smb2.Request) (smb2.GenericResponse, *s
 		ss.idleTime = time.Now()
 		tc, err := c.newTreeConnect(ss, tcr.PathName())
 		if err != nil {
-			if errors.Is(err, errNoShare) {
-				resp := smb2.NewErrorResponse(tcr, smb2.STATUS_INVALID_PARAMETER, nil)
-				return resp, ss, nil
-			}
 			if errors.Is(err, errAccessDenied) {
 				resp := smb2.NewErrorResponse(tcr, smb2.STATUS_ACCESS_DENIED, nil)
+				return resp, ss, nil
+			} else {
+				resp := smb2.NewErrorResponse(tcr, smb2.STATUS_INVALID_PARAMETER, nil)
 				return resp, ss, nil
 			}
 		}

--- a/server.go
+++ b/server.go
@@ -40,6 +40,13 @@ type Store interface {
 	GetShare(id types.Hash256, name string) (s stores.Share, err error)
 }
 
+// ServerHashLevel values.
+const (
+	HashEnableAll = iota
+	HashDisableAll
+	HashEnableShare
+)
+
 // server is the implementation of an SMB server.
 type server struct {
 	enabled                         bool
@@ -53,6 +60,7 @@ type server struct {
 	serverSideCopyMaxNumberOfChunks uint64
 	serverSideCopyMaxChunkSize      uint64
 	serverSideCopyMaxDataSize       uint64
+	serverHashLevel                 int
 
 	// Auxiliary fields.
 	listener        net.Listener
@@ -69,6 +77,7 @@ func newServer(l net.Listener, st Store) *server {
 		serverSideCopyMaxNumberOfChunks: 256,
 		serverSideCopyMaxChunkSize:      2 >> 10, // 1MiB
 		serverSideCopyMaxDataSize:       2 >> 14, // 16MiB
+		serverHashLevel:                 HashDisableAll,
 		shareList:                       make(map[string]*share),
 		connectionList:                  make(map[string]*connection),
 		globalOpenTable:                 make(map[uint64]*open),

--- a/smb2/close.go
+++ b/smb2/close.go
@@ -26,7 +26,7 @@ type CloseRequest struct {
 }
 
 // Validate implements GenericRequest interface.
-func (cr CloseRequest) Validate() error {
+func (cr CloseRequest) Validate(_ bool) error {
 	if err := Header(cr.data).Validate(); err != nil {
 		return err
 	}

--- a/smb2/error.go
+++ b/smb2/error.go
@@ -39,6 +39,7 @@ const (
 	STATUS_USER_SESSION_DELETED     = 0xc0000203
 	STATUS_NOT_FOUND                = 0xc0000225
 	STATUS_DUPLICATE_OBJECTID       = 0xc000022a
+	STATUS_SHARE_UNAVAILABLE        = 0xc0000480
 )
 
 // ErrorResponse represents an SMB2_ERROR response.

--- a/smb2/flush.go
+++ b/smb2/flush.go
@@ -16,7 +16,7 @@ type FlushRequest struct {
 }
 
 // Validate implements GenericRequest interface.
-func (fr FlushRequest) Validate() error {
+func (fr FlushRequest) Validate(_ bool) error {
 	if err := Header(fr.data).Validate(); err != nil {
 		return err
 	}

--- a/smb2/logoff.go
+++ b/smb2/logoff.go
@@ -18,7 +18,7 @@ type LogoffRequest struct {
 }
 
 // Validate implements GenericRequest interface.
-func (lr LogoffRequest) Validate() error {
+func (lr LogoffRequest) Validate(_ bool) error {
 	if err := Header(lr.data).Validate(); err != nil {
 		return err
 	}

--- a/smb2/request.go
+++ b/smb2/request.go
@@ -27,7 +27,7 @@ const (
 
 // GenericRequest implements a few common methods of SMB2 requests.
 type GenericRequest interface {
-	Validate() error
+	Validate(bool) error
 	Header() Header
 	CancelRequestID() uint64
 	GroupID() uint64
@@ -122,7 +122,7 @@ func GetRequests(data []byte, cid uint64) (reqs []*Request, err error) {
 }
 
 // Validate returns an error if the request is malformed, nil otherwise.
-func (req Request) Validate() error {
+func (req Request) Validate(_ bool) error {
 	return req.Header().Validate()
 }
 
@@ -268,7 +268,7 @@ type CancelRequest struct {
 }
 
 // Validate implements GenericRequest interface.
-func (cr CancelRequest) Validate() error {
+func (cr CancelRequest) Validate(_ bool) error {
 	if err := Header(cr.data).Validate(); err != nil {
 		return err
 	}
@@ -290,7 +290,7 @@ type EchoRequest struct {
 }
 
 // Validate implements GenericRequest interface.
-func (er EchoRequest) Validate() error {
+func (er EchoRequest) Validate(_ bool) error {
 	if err := Header(er.data).Validate(); err != nil {
 		return err
 	}

--- a/smb2/write.go
+++ b/smb2/write.go
@@ -10,6 +10,12 @@ const (
 	SMB2WriteResponseStructureSize = 17
 )
 
+const (
+	// SMB2_WRITE flags.
+	WRITEFLAG_WRITE_THROUGH    = 0x00000001
+	WRITEFLAG_WRITE_UNBUFFERED = 0x00000002
+)
+
 // WriteRequest represents an SMB2_WRITE request.
 type WriteRequest struct {
 	Request


### PR DESCRIPTION
This PR adds the support for the SMB dialect 2.1. The major difference with 2.0.2 is the support for multi-credit requests.