### PR TITLE
Support empty files

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -422,7 +422,6 @@ func (c *Client) UploadPart(ctx context.Context, r io.Reader, bucket, path, uplo
 // DeleteObject deletes a file or a directory.
 func (c *Client) DeleteObject(ctx context.Context, bucket, path string, batch bool) (err error) {
 	path = strings.ReplaceAll(path, "\\", "/") // Replace Windows formatting with the unified one
-	path = api.ObjectKeyEscape(path)
 	if batch {
 		err = c.doRequest(ctx, "POST", "/api/worker/objects/remove", api.ObjectsRemoveRequest{
 			Bucket: bucket,

--- a/conn.go
+++ b/conn.go
@@ -2441,16 +2441,14 @@ func (c *connection) cancelRequest(req *smb2.Request) error {
 		return err
 	}
 
-	var ss *session
-	var found bool
+	ss, found := c.sessionTable[cr.Header().SessionID()]
 	if cr.Header().IsFlagSet(smb2.FLAGS_SIGNED) {
-		ss, found = c.sessionTable[cr.Header().SessionID()]
-		if !found {
+		if found {
+			if !ss.validateRequest(req) {
+				return errInvalidSignature
+			}
+		} else {
 			return errSessionNotFound
-		}
-
-		if !ss.validateRequest(req) {
-			return errInvalidSignature
 		}
 	}
 
@@ -2459,7 +2457,14 @@ func (c *connection) cancelRequest(req *smb2.Request) error {
 	if cr.Header().IsFlagSet(smb2.FLAGS_ASYNC_COMMAND) {
 		target, found = c.asyncCommandList[cr.Header().AsyncID()]
 	} else {
-		target, found = c.requestList[cr.Header().MessageID()]
+		mid := cr.Header().MessageID()
+		for _, r := range c.asyncCommandList {
+			if r.Header().MessageID() == mid {
+				target = r
+				found = true
+				break
+			}
+		}
 	}
 
 	if !found {
@@ -2486,21 +2491,21 @@ func (c *connection) cancelRequest(req *smb2.Request) error {
 		}
 	}
 
+	if cr.IsEncrypted() {
+		target.SetEncrypted(true)
+	}
+
 	resp := smb2.NewErrorResponse(target, smb2.STATUS_CANCELLED, 0, nil)
 	resp.Header().ClearFlag(smb2.FLAGS_RELATED_OPERATIONS)
-	if cr.Header().IsFlagSet(smb2.FLAGS_ASYNC_COMMAND) {
+	if target.Header().IsFlagSet(smb2.FLAGS_ASYNC_COMMAND) {
 		resp.Header().SetFlag(smb2.FLAGS_ASYNC_COMMAND)
 		resp.Header().SetCreditResponse(0)
-		resp.Header().SetAsyncID(cr.Header().AsyncID())
+		resp.Header().SetAsyncID(target.Header().AsyncID())
 	}
 
 	c.server.writeResponse(c, ss, resp)
 
-	if cr.Header().IsFlagSet(smb2.FLAGS_ASYNC_COMMAND) {
-		delete(c.asyncCommandList, cr.Header().AsyncID())
-	} else {
-		delete(c.requestList, cr.Header().MessageID())
-	}
+	delete(c.asyncCommandList, target.Header().AsyncID())
 
 	ch, ok := c.stopChans[target.CancelRequestID()]
 	if ok {

--- a/conn.go
+++ b/conn.go
@@ -2276,7 +2276,7 @@ func (c *connection) processRequest(req *smb2.Request) (smb2.GenericResponse, *s
 				}
 
 				// Rename the file or the directory.
-				if op.size == 0 {
+				if op.size == 0 && op.fileAttributes&smb2.FILE_ATTRIBUTE_DIRECTORY == 0 {
 					tc.mu.Lock()
 					_, found := tc.persistedOpens[fri.FileName]
 					if found {

--- a/conn.go
+++ b/conn.go
@@ -769,13 +769,10 @@ func (c *connection) processRequest(req *smb2.Request) (smb2.GenericResponse, *s
 			}
 
 			info, err = tc.share.client.GetObjectInfo(ctx, tc.share.bucket, path)
-			if err != nil {
-				log.Printf("Error getting object info (bucket: %s, path: %s): %v\n", tc.share.bucket, path, err)
-				if errors.Is(err, context.DeadlineExceeded) {
-					cancel()
-					resp := smb2.NewErrorResponse(cr, smb2.STATUS_IO_TIMEOUT, 0, nil)
-					return resp, ss, nil
-				}
+			if err != nil && errors.Is(err, context.DeadlineExceeded) {
+				cancel()
+				resp := smb2.NewErrorResponse(cr, smb2.STATUS_IO_TIMEOUT, 0, nil)
+				return resp, ss, nil
 			}
 
 			switch cr.CreateDisposition() {

--- a/conn.go
+++ b/conn.go
@@ -2279,6 +2279,20 @@ func (c *connection) processRequest(req *smb2.Request) (smb2.GenericResponse, *s
 					return resp, ss, nil
 				}
 
+			case smb2.FileAllocationInformation:
+				if op.grantedAccess&smb2.FILE_WRITE_DATA == 0 {
+					resp := smb2.NewErrorResponse(sir, smb2.STATUS_ACCESS_DENIED, 0, nil)
+					return resp, ss, nil
+				}
+
+				buf := sir.Buffer()
+				if len(buf) != 8 {
+					resp := smb2.NewErrorResponse(sir, smb2.STATUS_INVALID_PARAMETER, 0, nil)
+					return resp, ss, nil
+				}
+
+				op.allocated = binary.LittleEndian.Uint64(buf)
+
 			default:
 				resp := smb2.NewErrorResponse(sir, smb2.STATUS_NOT_SUPPORTED, 0, nil)
 				return resp, ss, nil

--- a/conn.go
+++ b/conn.go
@@ -2003,6 +2003,10 @@ func (c *connection) processRequest(req *smb2.Request) (smb2.GenericResponse, *s
 				info = op.fileStandardInformation()
 			case smb2.FileNetworkOpenInformation:
 				info = op.fileNetworkOpenInformation()
+			case smb2.FileNormalizedNameInformation:
+				info = op.fileNormalizedNameInformation()
+			case smb2.FileEaInformation:
+				info = op.fileEaInformation()
 			case smb2.FileStreamInformation:
 				info = op.fileStreamInformation()
 			default: // Other classes are not supported yet

--- a/conn.go
+++ b/conn.go
@@ -2261,22 +2261,42 @@ func (c *connection) processRequest(req *smb2.Request) (smb2.GenericResponse, *s
 					return resp, ss, nil
 				}
 
+				if strings.Contains(fri.FileName, "/") || strings.Contains(fri.FileName, "\\") {
+					resp := smb2.NewErrorResponse(sir, smb2.STATUS_NOT_SUPPORTED, 0, nil)
+					return resp, ss, nil
+				}
+
 				if fri.RootDirectory != 0 {
 					resp := smb2.NewErrorResponse(sir, smb2.STATUS_INVALID_PARAMETER, 0, nil)
 					return resp, ss, nil
 				}
 
 				// Rename the file or the directory.
-				if err := tc.share.client.RenameObject(
-					op.ctx,
-					tc.share.bucket,
-					op.pathName,
-					fri.FileName,
-					op.fileAttributes&smb2.FILE_ATTRIBUTE_DIRECTORY > 0,
-					fri.ReplaceIfExists,
-				); err != nil {
-					resp := smb2.NewErrorResponse(sir, smb2.STATUS_OBJECT_NAME_COLLISION, 0, nil)
-					return resp, ss, nil
+				if op.size == 0 {
+					tc.mu.Lock()
+					_, found := tc.persistedOpens[fri.FileName]
+					if found {
+						tc.mu.Unlock()
+						resp := smb2.NewErrorResponse(sir, smb2.STATUS_OBJECT_NAME_COLLISION, 0, nil)
+						return resp, ss, nil
+					}
+					tc.persistedOpens[fri.FileName] = op
+					delete(tc.persistedOpens, op.pathName)
+					op.pathName = fri.FileName
+					op.lastModified = time.Now()
+					tc.mu.Unlock()
+				} else {
+					if err := tc.share.client.RenameObject(
+						op.ctx,
+						tc.share.bucket,
+						op.pathName,
+						fri.FileName,
+						op.fileAttributes&smb2.FILE_ATTRIBUTE_DIRECTORY > 0,
+						fri.ReplaceIfExists,
+					); err != nil {
+						resp := smb2.NewErrorResponse(sir, smb2.STATUS_OBJECT_NAME_COLLISION, 0, nil)
+						return resp, ss, nil
+					}
 				}
 
 			case smb2.FileAllocationInformation:

--- a/conn.go
+++ b/conn.go
@@ -1018,6 +1018,9 @@ func (c *connection) processRequest(req *smb2.Request) (smb2.GenericResponse, *s
 					op.size = op.pendingUpload.totalSize
 					op.allocated = op.pendingUpload.totalSize
 					op.pendingUpload = nil
+					tc.mu.Lock()
+					delete(tc.persistedOpens, op.pathName)
+					tc.mu.Unlock()
 				}
 			} else {
 				if err := op.treeConnect.share.client.AbortUpload(
@@ -1415,6 +1418,9 @@ func (c *connection) processRequest(req *smb2.Request) (smb2.GenericResponse, *s
 							op.size = size
 							op.allocated = size
 							op.pendingUpload = nil
+							tc.mu.Lock()
+							delete(tc.persistedOpens, op.pathName)
+							tc.mu.Unlock()
 						}
 					} else {
 						// If we don't know the file size, wait 10 minutes, then flush anyway.
@@ -1435,6 +1441,9 @@ func (c *connection) processRequest(req *smb2.Request) (smb2.GenericResponse, *s
 									op.size = size
 									op.allocated = size
 									op.pendingUpload = nil
+									tc.mu.Lock()
+									delete(tc.persistedOpens, op.pathName)
+									tc.mu.Unlock()
 								}
 							}
 						}(size)
@@ -2189,6 +2198,9 @@ func (c *connection) processRequest(req *smb2.Request) (smb2.GenericResponse, *s
 						if err == nil && len(buf) >= 8 {
 							op.handle = binary.LittleEndian.Uint64(buf[:8])
 						}
+						tc.mu.Lock()
+						delete(tc.persistedOpens, op.pathName)
+						tc.mu.Unlock()
 					}
 
 					op.size = size
@@ -2248,6 +2260,9 @@ func (c *connection) processRequest(req *smb2.Request) (smb2.GenericResponse, *s
 						if err == nil && len(buf) >= 8 {
 							op.handle = binary.LittleEndian.Uint64(buf[:8])
 						}
+						tc.mu.Lock()
+						delete(tc.persistedOpens, op.pathName)
+						tc.mu.Unlock()
 					}
 
 					op.size = size

--- a/conn.go
+++ b/conn.go
@@ -707,7 +707,7 @@ func (c *connection) processRequest(req *smb2.Request) (smb2.GenericResponse, *s
 			return resp, ss, nil
 		}
 
-		path := cr.Filename()
+		path := strings.ReplaceAll(cr.Filename(), "\\", "/")
 		co := cr.CreateOptions()
 		if co&smb2.FILE_DELETE_ON_CLOSE > 0 && (tc.maximalAccess&(smb2.DELETE|smb2.GENERIC_ALL|smb2.GENERIC_EXECUTE|smb2.GENERIC_READ|smb2.GENERIC_WRITE) == 0) {
 			resp := smb2.NewErrorResponse(cr, smb2.STATUS_ACCESS_DENIED, 0, nil)
@@ -904,7 +904,7 @@ func (c *connection) processRequest(req *smb2.Request) (smb2.GenericResponse, *s
 			}
 		}
 
-		if result == smb2.FILE_CREATED { // Persist the file for any future requests
+		if result == smb2.FILE_CREATED && op.fileAttributes&smb2.FILE_ATTRIBUTE_DIRECTORY == 0 { // Persist the file for any future requests
 			tc.mu.Lock()
 			tc.persistedOpens[path] = op
 			tc.mu.Unlock()
@@ -2265,28 +2265,25 @@ func (c *connection) processRequest(req *smb2.Request) (smb2.GenericResponse, *s
 					return resp, ss, nil
 				}
 
-				if strings.Contains(fri.FileName, "/") || strings.Contains(fri.FileName, "\\") {
-					resp := smb2.NewErrorResponse(sir, smb2.STATUS_NOT_SUPPORTED, 0, nil)
-					return resp, ss, nil
-				}
-
 				if fri.RootDirectory != 0 {
 					resp := smb2.NewErrorResponse(sir, smb2.STATUS_INVALID_PARAMETER, 0, nil)
 					return resp, ss, nil
 				}
 
 				// Rename the file or the directory.
+				newName := strings.ReplaceAll(fri.FileName, "\\", "/")
 				if op.size == 0 && op.fileAttributes&smb2.FILE_ATTRIBUTE_DIRECTORY == 0 {
 					tc.mu.Lock()
-					_, found := tc.persistedOpens[fri.FileName]
+					_, found := tc.persistedOpens[newName]
 					if found {
 						tc.mu.Unlock()
 						resp := smb2.NewErrorResponse(sir, smb2.STATUS_OBJECT_NAME_COLLISION, 0, nil)
 						return resp, ss, nil
 					}
-					tc.persistedOpens[fri.FileName] = op
+					tc.persistedOpens[newName] = op
 					delete(tc.persistedOpens, op.pathName)
-					op.pathName = fri.FileName
+					op.pathName = newName
+					op.fileName = utils.TrimPath(op.pathName)
 					op.lastModified = time.Now()
 					tc.mu.Unlock()
 				} else {
@@ -2294,7 +2291,7 @@ func (c *connection) processRequest(req *smb2.Request) (smb2.GenericResponse, *s
 						op.ctx,
 						tc.share.bucket,
 						op.pathName,
-						fri.FileName,
+						newName,
 						op.fileAttributes&smb2.FILE_ATTRIBUTE_DIRECTORY > 0,
 						fri.ReplaceIfExists,
 					); err != nil {

--- a/conn.go
+++ b/conn.go
@@ -104,9 +104,6 @@ func (c *connection) grantCredits(mid uint64, numCredits uint16) error {
 
 // acceptRequest processes an SMB message into one or more requests and puts them in the queue.
 func (c *connection) acceptRequest(msg []byte) error {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-
 	if uint64(len(msg)) > c.maxTransactSize+256 {
 		return errLongRequest
 	}
@@ -131,10 +128,13 @@ func (c *connection) acceptRequest(msg []byte) error {
 		}
 		tsid = smb2.Header(msg).TransformSessionID()
 		size = smb2.Header(msg).OriginalMessageSize()
+		c.mu.Lock()
 		ss, ok := c.sessionTable[tsid]
 		if !ok {
+			c.mu.Unlock()
 			return errSessionNotFound
 		}
+		c.mu.Unlock()
 		if ss.isAnonymous || ss.isGuest {
 			return errAccessDenied
 		}
@@ -174,7 +174,9 @@ func (c *connection) acceptRequest(msg []byte) error {
 			if c.negotiateDialect != smb2.SMB_DIALECT_UNKNOWN || len(reqs) > 1 {
 				return smb2.ErrWrongProtocol
 			}
+			c.mu.Lock()
 			c.grantCredits(mid, 1) // Grant just one credit
+			c.mu.Unlock()
 		} else {
 			if c.supportsMultiCredit {
 				if req.Header().Command() != smb2.SMB2_READ &&
@@ -198,7 +200,9 @@ func (c *connection) acceptRequest(msg []byte) error {
 				credits = 1
 			}
 
+			c.mu.Lock()
 			c.grantCredits(mid, credits)
+			c.mu.Unlock()
 			if req.Header().Command() == smb2.SMB2_CANCEL { // SMB2_CANCEL requests are handled separately
 				if err := c.cancelRequest(req); err != nil {
 					log.Printf("Couldn't cancel request %d:, %v\n", req.Header().Command(), err)
@@ -208,10 +212,13 @@ func (c *connection) acceptRequest(msg []byte) error {
 			}
 		}
 
+		c.mu.Lock()
 		_, ok := c.commandSequenceWindow[mid]
 		if !ok {
+			c.mu.Unlock()
 			return errRequestNotWithinWindow
 		}
+		c.mu.Unlock()
 
 		if mid == math.MaxUint64 {
 			return errCommandSecuenceWindowExceeded
@@ -220,7 +227,9 @@ func (c *connection) acceptRequest(msg []byte) error {
 		// If this is the first request in a chain of related requests, or if the requests are unrelated,
 		// find the associated session.
 		if i == 0 || req.GroupID() == 0 {
+			c.mu.Lock()
 			ss, found = c.sessionTable[req.Header().SessionID()]
+			c.mu.Unlock()
 		}
 
 		if found && !ss.validateRequest(req) {
@@ -228,6 +237,7 @@ func (c *connection) acceptRequest(msg []byte) error {
 		}
 
 		// Request processed; this message ID is not allowed anymore.
+		c.mu.Lock()
 		if c.negotiateDialect == smb2.SMB_DIALECT_202 || !c.supportsMultiCredit {
 			delete(c.commandSequenceWindow, mid)
 		} else { // Remove as many IDs as the CreditCharge field
@@ -245,6 +255,7 @@ func (c *connection) acceptRequest(msg []byte) error {
 
 		// Put request in the queue.
 		c.requestList[mid] = req
+		c.mu.Unlock()
 	}
 
 	return nil
@@ -2462,7 +2473,9 @@ func (c *connection) cancelRequest(req *smb2.Request) error {
 		return err
 	}
 
+	c.mu.Lock()
 	ss, found := c.sessionTable[cr.Header().SessionID()]
+	c.mu.Unlock()
 	if cr.Header().IsFlagSet(smb2.FLAGS_SIGNED) {
 		if found {
 			if !ss.validateRequest(req) {
@@ -2475,6 +2488,7 @@ func (c *connection) cancelRequest(req *smb2.Request) error {
 
 	// The provided request is an SMB2_CANCEL request; we need to find the target request.
 	var target *smb2.Request
+	c.mu.Lock()
 	if cr.Header().IsFlagSet(smb2.FLAGS_ASYNC_COMMAND) {
 		target, found = c.asyncCommandList[cr.Header().AsyncID()]
 	} else {
@@ -2487,6 +2501,7 @@ func (c *connection) cancelRequest(req *smb2.Request) error {
 			}
 		}
 	}
+	c.mu.Unlock()
 
 	if !found {
 		return nil
@@ -2526,6 +2541,7 @@ func (c *connection) cancelRequest(req *smb2.Request) error {
 
 	c.server.writeResponse(c, ss, resp)
 
+	c.mu.Lock()
 	delete(c.asyncCommandList, target.Header().AsyncID())
 
 	ch, ok := c.stopChans[target.CancelRequestID()]
@@ -2533,6 +2549,7 @@ func (c *connection) cancelRequest(req *smb2.Request) error {
 		close(ch)
 		delete(c.stopChans, target.CancelRequestID())
 	}
+	c.mu.Unlock()
 
 	return nil
 }

--- a/open.go
+++ b/open.go
@@ -382,6 +382,22 @@ func (op *open) fileNetworkOpenInformation() []byte {
 	return fnoi.Encode()
 }
 
+// fileNormalizedNameInformation genereates a FileNormalizedNameInfo structure.
+func (op *open) fileNormalizedNameInformation() []byte {
+	fnni := smb2.FileNormalizedNameInfo{
+		Filename: op.pathName,
+	}
+	return fnni.Encode()
+}
+
+// fileEaInformation genereates a FileEaInfo structure.
+func (op *open) fileEaInformation() []byte {
+	feai := smb2.FileEaInfo{
+		EaSize: 0,
+	}
+	return feai.Encode()
+}
+
 // fileStreamInformation generates a FileStreamInfo structure.
 func (op *open) fileStreamInformation() []byte {
 	fsi := smb2.FileStreamInfo{

--- a/open.go
+++ b/open.go
@@ -420,6 +420,30 @@ func (op *open) checkForChanges(req smb2.ChangeNotifyRequest, stopChan chan stru
 		return
 	}
 
+	found := make(map[string]struct{})
+	for _, entry := range objs {
+		if entry.Key == "" {
+			continue
+		}
+		if strings.HasPrefix(entry.Key[1:], op.pathName) {
+			found[entry.Key[1:]] = struct{}{}
+		}
+	}
+
+	tc := op.treeConnect
+	tc.mu.Lock()
+	for path, o := range tc.persistedOpens {
+		if _, ok := found[path]; ok {
+			continue
+		}
+		objs = append(objs, api.ObjectMetadata{
+			Bucket:  tc.share.bucket,
+			Key:     "/" + path,
+			ModTime: api.TimeRFC3339(o.lastModified),
+		})
+	}
+	tc.mu.Unlock()
+
 	snapshot := makeSnapshot(objs)
 	for {
 		select {
@@ -432,6 +456,30 @@ func (op *open) checkForChanges(req smb2.ChangeNotifyRequest, stopChan chan stru
 		if err != nil {
 			continue
 		}
+
+		found := make(map[string]struct{})
+		for _, entry := range objs {
+			if entry.Key == "" {
+				continue
+			}
+			if strings.HasPrefix(entry.Key[1:], op.pathName) {
+				found[entry.Key[1:]] = struct{}{}
+			}
+		}
+
+		tc := op.treeConnect
+		tc.mu.Lock()
+		for path, o := range tc.persistedOpens {
+			if _, ok := found[path]; ok {
+				continue
+			}
+			objs = append(objs, api.ObjectMetadata{
+				Bucket:  tc.share.bucket,
+				Key:     "/" + path,
+				ModTime: api.TimeRFC3339(o.lastModified),
+			})
+		}
+		tc.mu.Unlock()
 
 		newSnapshot := makeSnapshot(objs)
 		if !bytes.Equal(newSnapshot, snapshot) {

--- a/open.go
+++ b/open.go
@@ -253,11 +253,11 @@ func (op *open) queryDirectory(pattern string) error {
 	var results []api.ObjectMetadata
 	found := make(map[string]struct{})
 	for _, entry := range objs {
-		_, name, _ := utils.ExtractFilename(entry.Key)
+		path, name, _ := utils.ExtractFilename(entry.Key)
 		match, _ := filepath.Match(pattern, name)
 		if match {
 			results = append(results, entry)
-			found[name] = struct{}{}
+			found[path] = struct{}{}
 		}
 	}
 
@@ -268,7 +268,10 @@ func (op *open) queryDirectory(pattern string) error {
 		if _, ok := found[path]; ok {
 			continue
 		}
-		match, _ := filepath.Match(pattern, path)
+		if utils.TrimName(path) != op.pathName {
+			continue
+		}
+		match, _ := filepath.Match(pattern, utils.TrimPath(path))
 		if match {
 			results = append(results, api.ObjectMetadata{
 				Bucket:  tc.share.bucket,

--- a/open.go
+++ b/open.go
@@ -597,7 +597,7 @@ func (op *open) read(offset, length uint64) []byte {
 
 			data, err := readData(chunkOffset, toRead)
 			if err != nil {
-				log.Println("Error reading object:", err)
+				log.Printf("Error reading object: %s: %v", op.pathName, err)
 				return nil
 			}
 

--- a/open.go
+++ b/open.go
@@ -251,13 +251,33 @@ func (op *open) queryDirectory(pattern string) error {
 	}
 
 	var results []api.ObjectMetadata
+	found := make(map[string]struct{})
 	for _, entry := range objs {
 		_, name, _ := utils.ExtractFilename(entry.Key)
 		match, _ := filepath.Match(pattern, name)
 		if match {
 			results = append(results, entry)
+			found[name] = struct{}{}
 		}
 	}
+
+	// Search persisted Opens, too.
+	tc := op.treeConnect
+	tc.mu.Lock()
+	for path, o := range tc.persistedOpens {
+		if _, ok := found[path]; ok {
+			continue
+		}
+		match, _ := filepath.Match(pattern, path)
+		if match {
+			results = append(results, api.ObjectMetadata{
+				Bucket:  tc.share.bucket,
+				Key:     "/" + path,
+				ModTime: api.TimeRFC3339(o.lastModified),
+			})
+		}
+	}
+	tc.mu.Unlock()
 
 	op.lastSearch = pattern
 	op.searchResults = results

--- a/rpc/types.go
+++ b/rpc/types.go
@@ -37,7 +37,7 @@ func (sid *SyntaxID) Encode(w io.Writer) {
 	w.Write(buf)
 }
 
-// Decoder is an interface for decoding inbound MS-RPC packets.
+// Decode implements Decoder interface.
 func (sid *SyntaxID) Decode(r io.Reader) {
 	buf := make([]byte, 20)
 	_, err := r.Read(buf)
@@ -69,7 +69,7 @@ func (c *Context) Encode(w io.Writer) {
 	}
 }
 
-// Decoder is an interface for decoding inbound MS-RPC packets.
+// Decode implements Decoder interface.
 func (c *Context) Decode(r io.Reader) {
 	buf := make([]byte, 4)
 	_, err := r.Read(buf)
@@ -108,7 +108,7 @@ func (b *Bind) Encode(w io.Writer) {
 	}
 }
 
-// Decoder is an interface for decoding inbound MS-RPC packets.
+// Decode implements Decoder interface.
 func (b *Bind) Decode(r io.Reader) {
 	buf := make([]byte, 12)
 	_, err := r.Read(buf)
@@ -142,7 +142,7 @@ func (res *Result) Encode(w io.Writer) {
 	res.TransferSyntax.Encode(w)
 }
 
-// Decoder is an interface for decoding inbound MS-RPC packets.
+// Decode implements Decoder interface.
 func (res *Result) Decode(r io.Reader) {
 	buf := make([]byte, 4)
 	_, err := r.Read(buf)
@@ -184,7 +184,7 @@ func (ba *BindAck) Encode(w io.Writer) {
 	}
 }
 
-// Decoder is an interface for decoding inbound MS-RPC packets.
+// Decode implements Decoder interface.
 func (ba *BindAck) Decode(r io.Reader) {
 	buf := make([]byte, 10)
 	_, err := r.Read(buf)
@@ -243,7 +243,7 @@ func (req *Request) Encode(w io.Writer) {
 	w.Write(buf)
 }
 
-// Decoder is an interface for decoding inbound MS-RPC packets.
+// Decode implements Decoder interface.
 func (req *Request) Decode(r io.Reader) {
 	buf := make([]byte, 8)
 	_, err := r.Read(buf)
@@ -281,7 +281,7 @@ func (resp *Response) Encode(w io.Writer) {
 	w.Write(buf)
 }
 
-// Decoder is an interface for decoding inbound MS-RPC packets.
+// Decode implements Decoder interface.
 func (resp *Response) Decode(r io.Reader) {
 	buf := make([]byte, 8)
 	_, err := r.Read(buf)

--- a/smb2/query.go
+++ b/smb2/query.go
@@ -1120,6 +1120,20 @@ func (fnoi FileNetworkOpenInfo) Encode() []byte {
 	return buf
 }
 
+// FileNormalizedNameInfo is the output buffer structure for the FileNormalizedNameInformation info class.
+type FileNormalizedNameInfo struct {
+	Filename string
+}
+
+// Encode marshals the FileNormalizedNameInfo structure into a byte sequence.
+func (fnni FileNormalizedNameInfo) Encode() []byte {
+	fn := utils.EncodeStringToBytes(fnni.Filename)
+	buf := make([]byte, len(fn)+4)
+	binary.LittleEndian.PutUint32(buf[:4], uint32(len(fn)))
+	copy(buf[4:], fn)
+	return buf
+}
+
 // FileStreamInfo is the output buffer structure for the FileStreamInformation info class.
 type FileStreamInfo struct {
 	StreamName           string

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -33,6 +33,20 @@ func ExtractFilename(path string) (filepath string, filename string, isDir bool)
 	return
 }
 
+// TrimPath extracts the filename from an OS-specific path.
+func TrimPath(path string) string {
+	path = strings.ReplaceAll(path, "\\", "/")
+	parts := strings.Split(path, "/")
+	return parts[len(parts)-1]
+}
+
+// TrimName extracts the file path from an OS-specific path.
+func TrimName(path string) string {
+	path = strings.ReplaceAll(path, "\\", "/")
+	parts := strings.Split(path, "/")
+	return strings.Join(parts[:len(parts)-1], "/")
+}
+
 // FindMinKey finds a key-value pair with the smallest key in the map.
 func FindMinKey[T any](m map[uint64]T) (key uint64, value T) {
 	key = math.MaxUint64


### PR DESCRIPTION
This PR allows creating empty files (e.g. text documents) on Windows directly on the share.
Usage:
1. Right-click on the share window
2. Select `New... -> Text Document`
3. Choose another filename, if you like
4. Double-click on the file icon to edit it
5. Insert some content and save the file
Please note: The new file will only be uploaded to the Sia network, if it's not empty. You can't therefore delete the contents of a file and save it: the old contents will persist.