### PR TITLE
Refactor upload

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -2,466 +2,73 @@ package client
 
 import (
 	"context"
-	"encoding/binary"
-	"encoding/hex"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"io"
 	"net/http"
-	"net/url"
-	"slices"
 	"strings"
 	"time"
 
-	"github.com/mike76-dev/siasmb/smb2"
-	rhpv4 "go.sia.tech/core/rhp/v4"
-	"go.sia.tech/core/types"
 	"go.sia.tech/renterd/v2/api"
-	"golang.org/x/crypto/blake2b"
 )
 
-// Client implements a http.Client for interacting with renterd.
-type Client struct {
-	BaseURL  string
-	Password string
+// GeneralInfo contains some general information about the share.
+type GeneralInfo struct {
+	Bucket    string // a renterd only thing
+	CreatedAt time.Time
+}
+
+// StorageInfo contains all needed information about the underlying storage.
+type StorageInfo struct {
+	Type             string
+	RemainingStorage uint64
+	UsedStorage      uint64
+	MinShards        int
+	TotalShards      int
+}
+
+// FileInfo is a helper structure that combines the 64-bit and the 128-bit file IDs and the file creation time.
+type FileInfo struct {
+	ID64       uint64
+	ID         []byte
+	CreatedAt  time.Time
+	ModifiedAt time.Time
+}
+
+// ObjectInfo contains the most important information about an object.
+type ObjectInfo struct {
+	Key        string
+	ETag       string
+	CreatedAt  time.Time
+	ModifiedAt time.Time
+	Size       uint64
+}
+
+// Client provides an interface for accessing Sia-based remote shares.
+type Client interface {
+	Info(ctx context.Context, bucket string) (GeneralInfo, error)
+	Storage(ctx context.Context, bucket string) (StorageInfo, error)
+	List(ctx context.Context, bucket, path string) ([]ObjectInfo, error)
+	Object(ctx context.Context, bucket, path string) (ObjectInfo, error)
+	Parents(ctx context.Context, bucket, path string) (currentDir, parentDir FileInfo, err error)
+	Read(ctx context.Context, bucket, path string, offset, length uint64, buf io.Writer) error
+	StartUpload(ctx context.Context, bucket, path string) (uploadID []byte, err error)
+	AbortUpload(ctx context.Context, bucket, path string, uploadID []byte) (err error)
+	FinishUpload(ctx context.Context, bucket, path string, uploadID []byte, parts []api.MultipartCompletedPart) error
+	Write(ctx context.Context, r io.Reader, bucket, path string, uploadID []byte, partNumber int, offset, length uint64) (eTag string, err error)
+	Delete(ctx context.Context, bucket, path string, batch bool) error
+	Rename(ctx context.Context, bucket, oldName, newName string, isDir, force bool) error
+	MakeDirectory(ctx context.Context, bucket, path string) error
 }
 
 // New returns an initialized Client.
-func New(addr, password string) *Client {
-	return &Client{
-		BaseURL:  addr,
-		Password: password,
-	}
-}
-
-// GetBucket retrieves the information about a bucket.
-func (c *Client) GetBucket(ctx context.Context, name string) (bucket api.Bucket, err error) {
-	err = c.doRequest(ctx, "GET", fmt.Sprintf("/api/bus/bucket/%s", name), nil, &bucket)
-	return
-}
-
-// GetObject retrieves the information about a file.
-func (c *Client) GetObject(ctx context.Context, bucket, path string) (obj api.ObjectMetadata, err error) {
-	values := url.Values{}
-	values.Set("bucket", bucket)
-	api.GetObjectOptions{OnlyMetadata: true}.Apply(values)
-	path = strings.ReplaceAll(path, "\\", "/") // Replace Windows formatting with the unified one
-	path = api.ObjectKeyEscape(path)
-	path += "?" + values.Encode()
-	var res api.Object
-	err = c.doRequest(ctx, "GET", fmt.Sprintf("/api/bus/object/%s", path), nil, &res)
-	if err != nil {
-		return
-	}
-	obj = res.ObjectMetadata
-	return
-}
-
-// GetObjects lists the contents of a directory.
-func (c *Client) GetObjects(ctx context.Context, bucket, path string) (objs []api.ObjectMetadata, err error) {
-	values := url.Values{}
-	api.ListObjectOptions{
-		Bucket:    bucket,
-		Delimiter: "/",
-		Limit:     -1,
-	}.Apply(values)
-	path = strings.ReplaceAll(path, "\\", "/") // Replace Windows formatting with the unified one
-	path = api.ObjectKeyEscape(path)
-	path += "?" + values.Encode()
-	var res api.ObjectsResponse
-	err = c.doRequest(ctx, "GET", fmt.Sprintf("/api/bus/objects/%s", path), nil, &res)
-	if err != nil {
-		return
-	}
-	objs = res.Objects
-	return
-}
-
-// GetObjectInfo retrieves the information about a file or a directory.
-func (c *Client) GetObjectInfo(ctx context.Context, bucket, path string) (api.ObjectMetadata, error) {
-	path = strings.ReplaceAll(path, "\\", "/") // Replace Windows formatting with the unified one
-	if path == "" {                            // The root path: calculate the total size of the objects
-		b, err := c.GetBucket(ctx, bucket)
-		if err != nil {
-			return api.ObjectMetadata{}, err
-		}
-
-		objs, err := c.GetObjects(ctx, bucket, "")
-		if err != nil {
-			return api.ObjectMetadata{}, err
-		}
-
-		var size int64
-		for _, entry := range objs {
-			size += entry.Size
-		}
-
-		return api.ObjectMetadata{
-			Bucket:  bucket,
-			ModTime: b.CreatedAt,
-			Key:     "/",
-			Size:    size,
-		}, nil
-	}
-
-	var parentDir string
-	i := strings.LastIndex(path, "/")
-	if i < 0 {
-		parentDir = ""
-	} else {
-		parentDir = path[:i+1]
-	}
-
-	objs, err := c.GetObjects(ctx, bucket, parentDir)
-	if err != nil {
-		return api.ObjectMetadata{}, err
-	}
-
-	for _, entry := range objs {
-		if entry.Key == "/"+path || entry.Key == "/"+path+"/" {
-			return entry, nil
-		}
-	}
-
-	return api.ObjectMetadata{}, api.ErrObjectNotFound
-}
-
-// GetParentInfo retrieves the information about the current and the parent directories where the file is located.
-func (c *Client) GetParentInfo(ctx context.Context, bucket, path string) (dir, parentDir smb2.FileInfo, err error) {
-	var parent, grandParent, name, parentName string
-	if path != "" {
-		name = path + "/"
-	}
-
-	if i := strings.LastIndex(path, "/"); i >= 0 {
-		parent = path[:i]
-		if parent != "" {
-			parentName = parent + "/"
-		}
-
-		if j := strings.LastIndex(parent, "/"); j >= 0 {
-			grandParent = parent[:j]
-		}
-	}
-
-	if parent != "" {
-		parent += "/"
-	}
-
-	if grandParent != "" {
-		grandParent += "/"
-	}
-
-	var b api.Bucket
-	if parent == "" || grandParent == "" {
-		b, err = c.GetBucket(ctx, bucket)
-		if err != nil {
-			return
-		}
-	}
-
-	var objs []api.ObjectMetadata
-	if parent != "" {
-		objs, err = c.GetObjects(ctx, bucket, parent)
-		if err != nil {
-			return
-		}
-
-		for _, entry := range objs {
-			if entry.Key == name {
-				etag, _ := hex.DecodeString(entry.ETag)
-				if len(etag) >= 8 {
-					dir.ID64 = binary.LittleEndian.Uint64(etag[:8])
-				}
-
-				dir.CreatedAt = time.Time(entry.ModTime)
-				dir.ID = make([]byte, 16)
-				break
-			}
-		}
-	} else {
-		hash := blake2b.Sum256([]byte("/"))
-		dir.ID64 = binary.LittleEndian.Uint64(hash[:8])
-		dir.CreatedAt = time.Time(b.CreatedAt)
-		dir.ID = make([]byte, 16)
-	}
-
-	if grandParent != "" {
-		objs, err = c.GetObjects(ctx, bucket, grandParent)
-		if err != nil {
-			return
-		}
-
-		for _, entry := range objs {
-			if entry.Key == parentName {
-				etag, _ := hex.DecodeString(entry.ETag)
-				if len(etag) >= 8 {
-					parentDir.ID64 = binary.LittleEndian.Uint64(etag[:8])
-				}
-
-				parentDir.CreatedAt = time.Time(entry.ModTime)
-				parentDir.ID = make([]byte, 16)
-				break
-			}
-		}
-	} else {
-		hash := blake2b.Sum256([]byte("/"))
-		parentDir.ID64 = binary.LittleEndian.Uint64(hash[:8])
-		parentDir.CreatedAt = time.Time(b.CreatedAt)
-		parentDir.ID = make([]byte, 16)
-	}
-
-	if parentDir.ID64 == dir.ID64 {
-		parentDir.ID64 = 0
-	}
-
-	return
-}
-
-// Redundancy retrieves the renterd redundancy settings.
-func (c *Client) Redundancy(ctx context.Context) (rs api.RedundancySettings, err error) {
-	var resp api.UploadSettings
-	err = c.doRequest(ctx, "GET", "/api/bus/settings/upload", nil, &resp)
-	if err != nil {
-		return
-	}
-	return resp.Redundancy, nil
-}
-
-// contracts retrieves the renterd contracts.
-func (c *Client) contracts(ctx context.Context) (contracts []api.ContractMetadata, err error) {
-	err = c.doRequest(ctx, "GET", "/api/bus/contracts", nil, &contracts)
-	return
-}
-
-// host retrieves the information about a particular host by its public key.
-func (c *Client) host(ctx context.Context, pk types.PublicKey) (h api.Host, err error) {
-	err = c.doRequest(ctx, "GET", fmt.Sprintf("/api/bus/host/%s", pk), nil, &h)
-	return
-}
-
-// RemainingStorage calculates the total remaining storage of all hosts that renterd has active contracts with.
-func (c *Client) RemainingStorage(ctx context.Context) (rs uint64, err error) {
-	var contracts []api.ContractMetadata
-	contracts, err = c.contracts(ctx)
-	if err != nil {
-		return
-	}
-	for _, contract := range contracts {
-		if contract.State != api.ContractStateActive {
-			continue
-		}
-		var h api.Host
-		h, err = c.host(ctx, contract.HostKey)
-		if err != nil {
-			return
-		}
-		rs += h.V2Settings.RemainingStorage
-	}
-	return rs * rhpv4.SectorSize, nil
-}
-
-// UsedStorage retrieves the "used" storage, meaning the total size of uploaded sectors including redundancy.
-func (c *Client) UsedStorage(ctx context.Context, bucket string) (us uint64, err error) {
-	values := url.Values{}
-	values.Set("bucket", bucket)
-	var osr api.ObjectsStatsResponse
-	err = c.doRequest(ctx, "GET", "/api/bus/stats/objects?"+values.Encode(), nil, &osr)
-	if err != nil {
-		return
-	}
-	return osr.TotalUploadedSize, nil
-}
-
-// ReadObject downloads a file from the Sia network.
-func (c *Client) ReadObject(ctx context.Context, bucket, path string, offset, length uint64, buf io.Writer) (err error) {
-	values := url.Values{}
-	values.Set("bucket", bucket)
-
-	// url.PathEscape does the full escape, so we need to convert any escaped forward slashes back.
-	path = strings.ReplaceAll(url.PathEscape(path), "%2F", "/")
-	path = fmt.Sprintf("/api/worker/object/%s?"+values.Encode(), path)
-
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, fmt.Sprintf("%v%v", c.BaseURL, path), nil)
-	if err != nil {
-		return
-	}
-
-	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("Range", fmt.Sprintf("bytes=%d-%d", offset, offset+length-1))
-	if c.Password != "" {
-		req.SetBasicAuth("", c.Password)
-	}
-
-	resp, err := http.DefaultClient.Do(req)
-	if err != nil {
-		return err
-	}
-
-	defer io.Copy(io.Discard, resp.Body)
-	defer resp.Body.Close()
-	if !(200 <= resp.StatusCode && resp.StatusCode < 300) {
-		err, _ := io.ReadAll(resp.Body)
-		return errors.New(string(err))
-	}
-
-	if resp == nil {
+func New(clientType, addr, password string) Client {
+	switch clientType {
+	case "renterd":
+		return newRenterdClient(addr, password)
+	default:
 		return nil
 	}
-
-	_, err = io.Copy(buf, resp.Body)
-	return
-}
-
-// StartUpload initiates a multipart upload.
-func (c *Client) StartUpload(ctx context.Context, bucket, path string) (uploadID string, err error) {
-	if strings.HasSuffix(path, ":Zone.Identifier") { // Don't upload Windows' zone identifier files
-		return
-	}
-	path = strings.ReplaceAll(path, "\\", "/") // Replace Windows formatting with the unified one
-	var resp api.MultipartCreateResponse
-	if err = c.doRequest(ctx, "POST", "/api/bus/multipart/create", api.MultipartCreateRequest{
-		Bucket: bucket,
-		Key:    "/" + path,
-	}, &resp); err != nil {
-		return
-	}
-	return resp.UploadID, nil
-}
-
-// AbortUpload aborts an initiated multipart upload.
-func (c *Client) AbortUpload(ctx context.Context, bucket, path string, uploadID string) (err error) {
-	if strings.HasSuffix(path, ":Zone.Identifier") { // Don't upload Windows' zone identifier files
-		return
-	}
-	path = strings.ReplaceAll(path, "\\", "/") // Replace Windows formatting with the unified one
-	err = c.doRequest(ctx, "POST", "/api/bus/multipart/abort", api.MultipartAbortRequest{
-		Bucket:   bucket,
-		Key:      "/" + path,
-		UploadID: uploadID,
-	}, nil)
-	return
-}
-
-// FinishUpload completes a multipart upload.
-func (c *Client) FinishUpload(ctx context.Context, bucket, path string, uploadID string, parts []api.MultipartCompletedPart) (eTag string, err error) {
-	if strings.HasSuffix(path, ":Zone.Identifier") { // Don't upload Windows' zone identifier files
-		return
-	}
-	path = strings.ReplaceAll(path, "\\", "/") // Replace Windows formatting with the unified one
-
-	// The parts may come out of order, but renterd will error back, so we need to sort them.
-	slices.SortFunc(parts, func(a, b api.MultipartCompletedPart) int { return a.PartNumber - b.PartNumber })
-	var resp api.MultipartCompleteResponse
-	if err = c.doRequest(ctx, "POST", "/api/bus/multipart/complete", api.MultipartCompleteRequest{
-		Bucket:   bucket,
-		Key:      "/" + path,
-		UploadID: uploadID,
-		Parts:    parts,
-	}, &resp); err != nil {
-		return
-	}
-	return resp.ETag, nil
-}
-
-// UploadPart uploads the provided chunk of data to the Sia network.
-func (c *Client) UploadPart(ctx context.Context, r io.Reader, bucket, path, uploadID string, partNumber int, offset, length uint64) (eTag string, err error) {
-	if strings.HasSuffix(path, ":Zone.Identifier") { // Don't upload Windows' zone identifier files
-		return
-	}
-	path = strings.ReplaceAll(path, "\\", "/") // Replace Windows formatting with the unified one
-	path = api.ObjectKeyEscape(path)
-	values := make(url.Values)
-	values.Set("bucket", bucket)
-	values.Set("uploadid", uploadID)
-	values.Set("partnumber", fmt.Sprint(partNumber))
-
-	off := int(offset)
-	opts := api.UploadMultipartUploadPartOptions{
-		EncryptionOffset: &off,
-		ContentLength:    int64(length),
-	}
-	opts.Apply(values)
-
-	u, err := url.Parse(fmt.Sprintf("%v/api/worker/multipart/%v", c.BaseURL, path))
-	if err != nil {
-		return
-	}
-	u.RawQuery = values.Encode()
-
-	req, err := http.NewRequestWithContext(ctx, "PUT", u.String(), r)
-	if err != nil {
-		return
-	}
-
-	req.SetBasicAuth("", c.Password)
-	if length != 0 {
-		req.ContentLength = int64(length)
-	} else if req.ContentLength, err = sizeFromSeeker(r); err != nil {
-		return "", fmt.Errorf("failed to get content length from seeker: %v", err)
-	}
-
-	resp, err := http.DefaultClient.Do(req)
-	if err != nil {
-		return
-	}
-
-	defer resp.Body.Close()
-	defer io.Copy(io.Discard, resp.Body)
-
-	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		lr := io.LimitReader(resp.Body, 1<<20) // 1MiB limit
-		errMsg, _ := io.ReadAll(lr)
-		return "", fmt.Errorf("HTTP error: %s (status: %d)", string(errMsg), resp.StatusCode)
-	}
-
-	return resp.Header.Get("ETag"), nil
-}
-
-// DeleteObject deletes a file or a directory.
-func (c *Client) DeleteObject(ctx context.Context, bucket, path string, batch bool) (err error) {
-	path = strings.ReplaceAll(path, "\\", "/") // Replace Windows formatting with the unified one
-	if batch {
-		err = c.doRequest(ctx, "POST", "/api/worker/objects/remove", api.ObjectsRemoveRequest{
-			Bucket: bucket,
-			Prefix: "/" + path + "/",
-		}, nil)
-	} else {
-		values := make(url.Values)
-		values.Set("bucket", bucket)
-		err = c.doRequest(ctx, "DELETE", fmt.Sprintf("/api/worker/object/%s?"+values.Encode(), path), nil, nil)
-	}
-	return
-}
-
-// MakeDirectory creates a new directory in the specified path.
-func (c *Client) MakeDirectory(ctx context.Context, bucket, path string) (err error) {
-	path = strings.ReplaceAll(path, "\\", "/") // Replace Windows formatting with the unified one
-	path = api.ObjectKeyEscape(path)
-	path += "/"
-	values := make(url.Values)
-	values.Set("bucket", bucket)
-	err = c.doRequest(ctx, "PUT", fmt.Sprintf("/api/worker/object/%s?"+values.Encode(), path), nil, nil)
-	return
-}
-
-// RenameObject renames a file or a directory.
-func (c *Client) RenameObject(ctx context.Context, bucket, oldName, newName string, isDir, force bool) (err error) {
-	mode := api.ObjectsRenameModeSingle
-	if isDir {
-		oldName += "/"
-		newName += "/"
-		mode = api.ObjectsRenameModeMulti
-	}
-	err = c.doRequest(ctx, "POST", "/api/bus/objects/rename", api.ObjectsRenameRequest{
-		Bucket: bucket,
-		Force:  force,
-		From:   "/" + oldName,
-		To:     "/" + newName,
-		Mode:   mode,
-	}, nil)
-	return
 }
 
 // sizeFromSeeker tries to find out the size of a file.
@@ -481,8 +88,14 @@ func sizeFromSeeker(r io.Reader) (int64, error) {
 	return size, nil
 }
 
+// clientParams holds the basic params of a Client.
+type clientParams struct {
+	baseURL  string
+	password string
+}
+
 // doRequest does everything needed to send an HTTP request and receive a response.
-func (c *Client) doRequest(ctx context.Context, method, path string, body interface{}, resp interface{}) error {
+func (cp clientParams) doRequest(ctx context.Context, method, path string, body interface{}, resp interface{}) error {
 	var reqBody io.Reader
 	if body != nil {
 		data, err := json.Marshal(body)
@@ -492,14 +105,14 @@ func (c *Client) doRequest(ctx context.Context, method, path string, body interf
 		reqBody = strings.NewReader(string(data))
 	}
 
-	req, err := http.NewRequestWithContext(ctx, method, c.BaseURL+path, reqBody)
+	req, err := http.NewRequestWithContext(ctx, method, cp.baseURL+path, reqBody)
 	if err != nil {
 		return err
 	}
 
 	req.Header.Set("Content-Type", "application/json")
-	if c.Password != "" {
-		req.SetBasicAuth("", c.Password)
+	if cp.password != "" {
+		req.SetBasicAuth("", cp.password)
 	}
 
 	r, err := http.DefaultClient.Do(req)

--- a/client/client.go
+++ b/client/client.go
@@ -52,10 +52,10 @@ type Client interface {
 	Object(ctx context.Context, bucket, path string) (ObjectInfo, error)
 	Parents(ctx context.Context, bucket, path string) (currentDir, parentDir FileInfo, err error)
 	Read(ctx context.Context, bucket, path string, offset, length uint64, buf io.Writer) error
-	StartUpload(ctx context.Context, bucket, path string) (uploadID []byte, err error)
-	AbortUpload(ctx context.Context, bucket, path string, uploadID []byte) (err error)
-	FinishUpload(ctx context.Context, bucket, path string, uploadID []byte, parts []api.MultipartCompletedPart) error
-	Write(ctx context.Context, r io.Reader, bucket, path string, uploadID []byte, partNumber int, offset, length uint64) (eTag string, err error)
+	StartUpload(ctx context.Context, bucket, path string) (uploadID string, err error)
+	AbortUpload(ctx context.Context, bucket, path string, uploadID string) (err error)
+	FinishUpload(ctx context.Context, bucket, path string, uploadID string, parts []api.MultipartCompletedPart) error
+	Write(ctx context.Context, r io.Reader, bucket, path string, uploadID string, partNumber int, offset, length uint64) (eTag string, err error)
 	Delete(ctx context.Context, bucket, path string, batch bool) error
 	Rename(ctx context.Context, bucket, oldName, newName string, isDir, force bool) error
 	MakeDirectory(ctx context.Context, bucket, path string) error

--- a/client/renterd.go
+++ b/client/renterd.go
@@ -1,0 +1,492 @@
+package client
+
+import (
+	"context"
+	"encoding/binary"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"slices"
+	"strings"
+	"time"
+
+	rhpv4 "go.sia.tech/core/rhp/v4"
+	"go.sia.tech/core/types"
+	"go.sia.tech/renterd/v2/api"
+	"golang.org/x/crypto/blake2b"
+)
+
+// renterdClient implements a Client for interacting with renterd.
+type renterdClient struct {
+	clientParams
+}
+
+// newRenterdClient returns an initialized renterdClient.
+func newRenterdClient(addr, password string) Client {
+	return &renterdClient{
+		clientParams: clientParams{
+			baseURL:  addr,
+			password: password,
+		},
+	}
+}
+
+// Info queries the general information about the share.
+func (rc *renterdClient) Info(ctx context.Context, bucketName string) (GeneralInfo, error) {
+	var bucket api.Bucket
+	if err := rc.doRequest(ctx, "GET", fmt.Sprintf("/api/bus/bucket/%s", bucketName), nil, &bucket); err != nil {
+		return GeneralInfo{}, err
+	}
+
+	return GeneralInfo{
+		Bucket:    bucket.Name,
+		CreatedAt: time.Time(bucket.CreatedAt),
+	}, nil
+}
+
+// Storage queries the information about the underlying storage.
+func (rc *renterdClient) Storage(ctx context.Context, bucket string) (StorageInfo, error) {
+	r, err := rc.redundancy(ctx)
+	if err != nil {
+		return StorageInfo{}, err
+	}
+	if r.MinShards == 0 || r.TotalShards == 0 {
+		return StorageInfo{}, errors.New("zero shards not allowed")
+	}
+
+	rs, err := rc.remainingStorage(ctx)
+	if err != nil {
+		return StorageInfo{}, err
+	}
+
+	us, err := rc.usedStorage(ctx, bucket)
+	if err != nil {
+		return StorageInfo{}, err
+	}
+
+	return StorageInfo{
+		Type:             "renterd",
+		RemainingStorage: rs,
+		UsedStorage:      us,
+		MinShards:        r.MinShards,
+		TotalShards:      r.TotalShards,
+	}, nil
+}
+
+// redundancy retrieves the renterd redundancy settings.
+func (rc *renterdClient) redundancy(ctx context.Context) (rs api.RedundancySettings, err error) {
+	var resp api.UploadSettings
+	err = rc.doRequest(ctx, "GET", "/api/bus/settings/upload", nil, &resp)
+	if err != nil {
+		return
+	}
+	return resp.Redundancy, nil
+}
+
+// contracts retrieves the renterd contracts.
+func (rc *renterdClient) contracts(ctx context.Context) (contracts []api.ContractMetadata, err error) {
+	err = rc.doRequest(ctx, "GET", "/api/bus/contracts", nil, &contracts)
+	return
+}
+
+// host retrieves the information about a particular host by its public key.
+func (rc *renterdClient) host(ctx context.Context, pk types.PublicKey) (h api.Host, err error) {
+	err = rc.doRequest(ctx, "GET", fmt.Sprintf("/api/bus/host/%s", pk), nil, &h)
+	return
+}
+
+// remainingStorage calculates the total remaining storage of all hosts that renterd has active contracts with.
+func (rc *renterdClient) remainingStorage(ctx context.Context) (rs uint64, err error) {
+	var contracts []api.ContractMetadata
+	contracts, err = rc.contracts(ctx)
+	if err != nil {
+		return
+	}
+	for _, contract := range contracts {
+		if contract.State != api.ContractStateActive {
+			continue
+		}
+		var h api.Host
+		h, err = rc.host(ctx, contract.HostKey)
+		if err != nil {
+			return
+		}
+		rs += h.V2Settings.RemainingStorage
+	}
+	return rs * rhpv4.SectorSize, nil
+}
+
+// usedStorage retrieves the "used" storage, meaning the total size of uploaded sectors including redundancy.
+func (rc *renterdClient) usedStorage(ctx context.Context, bucket string) (us uint64, err error) {
+	values := url.Values{}
+	values.Set("bucket", bucket)
+	var osr api.ObjectsStatsResponse
+	err = rc.doRequest(ctx, "GET", "/api/bus/stats/objects?"+values.Encode(), nil, &osr)
+	if err != nil {
+		return
+	}
+	return osr.TotalUploadedSize, nil
+}
+
+// List lists the contents of a directory.
+func (rc *renterdClient) List(ctx context.Context, bucket, path string) (ois []ObjectInfo, err error) {
+	values := url.Values{}
+	api.ListObjectOptions{
+		Bucket:    bucket,
+		Delimiter: "/",
+		Limit:     -1,
+	}.Apply(values)
+	path = strings.ReplaceAll(path, "\\", "/") // Replace Windows formatting with the unified one
+	path = api.ObjectKeyEscape(path)
+	path += "?" + values.Encode()
+	var res api.ObjectsResponse
+	err = rc.doRequest(ctx, "GET", fmt.Sprintf("/api/bus/objects/%s", path), nil, &res)
+	if err != nil {
+		return
+	}
+
+	for _, obj := range res.Objects {
+		ois = append(ois, ObjectInfo{
+			Key:        obj.Key,
+			ETag:       obj.ETag,
+			CreatedAt:  time.Time(obj.ModTime),
+			ModifiedAt: time.Time(obj.ModTime),
+			Size:       uint64(obj.Size),
+		})
+	}
+
+	return
+}
+
+// Object retrieves the information about a file or a directory.
+func (rc *renterdClient) Object(ctx context.Context, bucket, path string) (ObjectInfo, error) {
+	path = strings.ReplaceAll(path, "\\", "/") // Replace Windows formatting with the unified one
+	if path == "" {                            // The root path: calculate the total size of the objects
+		info, err := rc.Info(ctx, bucket)
+		if err != nil {
+			return ObjectInfo{}, err
+		}
+
+		ois, err := rc.List(ctx, bucket, "")
+		if err != nil {
+			return ObjectInfo{}, err
+		}
+
+		var size uint64
+		for _, oi := range ois {
+			size += oi.Size
+		}
+
+		return ObjectInfo{
+			Key:        "/",
+			CreatedAt:  info.CreatedAt,
+			ModifiedAt: info.CreatedAt,
+			Size:       size,
+		}, nil
+	}
+
+	var parentDir string
+	i := strings.LastIndex(path, "/")
+	if i < 0 {
+		parentDir = ""
+	} else {
+		parentDir = path[:i+1]
+	}
+
+	ois, err := rc.List(ctx, bucket, parentDir)
+	if err != nil {
+		return ObjectInfo{}, err
+	}
+
+	for _, oi := range ois {
+		if oi.Key == "/"+path || oi.Key == "/"+path+"/" {
+			return oi, nil
+		}
+	}
+
+	return ObjectInfo{}, api.ErrObjectNotFound
+}
+
+// Parents retrieves the information about the current and the parent directories where the file is located.
+func (rc *renterdClient) Parents(ctx context.Context, bucket, path string) (currentDir, parentDir FileInfo, err error) {
+	var parent, grandParent, name, parentName string
+	if path != "" {
+		name = path + "/"
+	}
+
+	if i := strings.LastIndex(path, "/"); i >= 0 {
+		parent = path[:i]
+		if parent != "" {
+			parentName = parent + "/"
+		}
+
+		if j := strings.LastIndex(parent, "/"); j >= 0 {
+			grandParent = parent[:j]
+		}
+	}
+
+	if parent != "" {
+		parent += "/"
+	}
+
+	if grandParent != "" {
+		grandParent += "/"
+	}
+
+	var info GeneralInfo
+	if parent == "" || grandParent == "" {
+		info, err = rc.Info(ctx, bucket)
+		if err != nil {
+			return
+		}
+	}
+
+	var ois []ObjectInfo
+	if parent != "" {
+		ois, err = rc.List(ctx, bucket, parent)
+		if err != nil {
+			return
+		}
+
+		for _, oi := range ois {
+			if oi.Key == name {
+				etag, _ := hex.DecodeString(oi.ETag)
+				if len(etag) >= 8 {
+					currentDir.ID64 = binary.LittleEndian.Uint64(etag[:8])
+				}
+
+				currentDir.CreatedAt = oi.CreatedAt
+				currentDir.ModifiedAt = oi.ModifiedAt
+				currentDir.ID = make([]byte, 16)
+				break
+			}
+		}
+	} else {
+		hash := blake2b.Sum256([]byte("/"))
+		currentDir.ID64 = binary.LittleEndian.Uint64(hash[:8])
+		currentDir.CreatedAt = info.CreatedAt
+		currentDir.ModifiedAt = info.CreatedAt
+		currentDir.ID = make([]byte, 16)
+	}
+
+	if grandParent != "" {
+		ois, err = rc.List(ctx, bucket, grandParent)
+		if err != nil {
+			return
+		}
+
+		for _, oi := range ois {
+			if oi.Key == parentName {
+				etag, _ := hex.DecodeString(oi.ETag)
+				if len(etag) >= 8 {
+					parentDir.ID64 = binary.LittleEndian.Uint64(etag[:8])
+				}
+
+				parentDir.CreatedAt = oi.CreatedAt
+				parentDir.ModifiedAt = oi.ModifiedAt
+				parentDir.ID = make([]byte, 16)
+				break
+			}
+		}
+	} else {
+		hash := blake2b.Sum256([]byte("/"))
+		parentDir.ID64 = binary.LittleEndian.Uint64(hash[:8])
+		parentDir.CreatedAt = info.CreatedAt
+		parentDir.ModifiedAt = info.CreatedAt
+		parentDir.ID = make([]byte, 16)
+	}
+
+	if parentDir.ID64 == currentDir.ID64 {
+		parentDir.ID64 = 0
+	}
+
+	return
+}
+
+// Read downloads a file from the Sia network.
+func (rc *renterdClient) Read(ctx context.Context, bucket, path string, offset, length uint64, buf io.Writer) (err error) {
+	values := url.Values{}
+	values.Set("bucket", bucket)
+
+	// url.PathEscape does the full escape, so we need to convert any escaped forward slashes back.
+	path = strings.ReplaceAll(url.PathEscape(path), "%2F", "/")
+	path = fmt.Sprintf("/api/worker/object/%s?"+values.Encode(), path)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, fmt.Sprintf("%v%v", rc.baseURL, path), nil)
+	if err != nil {
+		return
+	}
+
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Range", fmt.Sprintf("bytes=%d-%d", offset, offset+length-1))
+	if rc.password != "" {
+		req.SetBasicAuth("", rc.password)
+	}
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return err
+	}
+
+	defer io.Copy(io.Discard, resp.Body)
+	defer resp.Body.Close()
+	if !(200 <= resp.StatusCode && resp.StatusCode < 300) {
+		err, _ := io.ReadAll(resp.Body)
+		return errors.New(string(err))
+	}
+
+	if resp == nil {
+		return nil
+	}
+
+	_, err = io.Copy(buf, resp.Body)
+	return
+}
+
+// StartUpload initiates a multipart upload.
+func (rc *renterdClient) StartUpload(ctx context.Context, bucket, path string) (uploadID []byte, err error) {
+	if strings.HasSuffix(path, ":Zone.Identifier") { // Don't upload Windows' zone identifier files
+		return
+	}
+	path = strings.ReplaceAll(path, "\\", "/") // Replace Windows formatting with the unified one
+	var resp api.MultipartCreateResponse
+	if err = rc.doRequest(ctx, "POST", "/api/bus/multipart/create", api.MultipartCreateRequest{
+		Bucket: bucket,
+		Key:    "/" + path,
+	}, &resp); err != nil {
+		return
+	}
+	return []byte(resp.UploadID), nil
+}
+
+// AbortUpload aborts an initiated multipart upload.
+func (rc *renterdClient) AbortUpload(ctx context.Context, bucket, path string, uploadID []byte) (err error) {
+	if strings.HasSuffix(path, ":Zone.Identifier") { // Don't upload Windows' zone identifier files
+		return
+	}
+	path = strings.ReplaceAll(path, "\\", "/") // Replace Windows formatting with the unified one
+	err = rc.doRequest(ctx, "POST", "/api/bus/multipart/abort", api.MultipartAbortRequest{
+		Bucket:   bucket,
+		Key:      "/" + path,
+		UploadID: string(uploadID),
+	}, nil)
+	return
+}
+
+// FinishUpload completes a multipart upload.
+func (rc *renterdClient) FinishUpload(ctx context.Context, bucket, path string, uploadID []byte, parts []api.MultipartCompletedPart) error {
+	if strings.HasSuffix(path, ":Zone.Identifier") { // Don't upload Windows' zone identifier files
+		return nil
+	}
+	path = strings.ReplaceAll(path, "\\", "/") // Replace Windows formatting with the unified one
+
+	// The parts may come out of order, but renterd will error back, so we need to sort them.
+	slices.SortFunc(parts, func(a, b api.MultipartCompletedPart) int { return a.PartNumber - b.PartNumber })
+	var resp api.MultipartCompleteResponse
+	return rc.doRequest(ctx, "POST", "/api/bus/multipart/complete", api.MultipartCompleteRequest{
+		Bucket:   bucket,
+		Key:      "/" + path,
+		UploadID: string(uploadID),
+		Parts:    parts,
+	}, &resp)
+}
+
+// Write uploads the provided chunk of data to the Sia network.
+func (rc *renterdClient) Write(ctx context.Context, r io.Reader, bucket, path string, uploadID []byte, partNumber int, offset, length uint64) (eTag string, err error) {
+	if strings.HasSuffix(path, ":Zone.Identifier") { // Don't upload Windows' zone identifier files
+		return
+	}
+	path = strings.ReplaceAll(path, "\\", "/") // Replace Windows formatting with the unified one
+	path = api.ObjectKeyEscape(path)
+	values := make(url.Values)
+	values.Set("bucket", bucket)
+	values.Set("uploadid", string(uploadID))
+	values.Set("partnumber", fmt.Sprint(partNumber))
+
+	off := int(offset)
+	opts := api.UploadMultipartUploadPartOptions{
+		EncryptionOffset: &off,
+		ContentLength:    int64(length),
+	}
+	opts.Apply(values)
+
+	u, err := url.Parse(fmt.Sprintf("%v/api/worker/multipart/%v", rc.baseURL, path))
+	if err != nil {
+		return
+	}
+	u.RawQuery = values.Encode()
+
+	req, err := http.NewRequestWithContext(ctx, "PUT", u.String(), r)
+	if err != nil {
+		return
+	}
+
+	req.SetBasicAuth("", rc.password)
+	if length != 0 {
+		req.ContentLength = int64(length)
+	} else if req.ContentLength, err = sizeFromSeeker(r); err != nil {
+		return "", fmt.Errorf("failed to get content length from seeker: %v", err)
+	}
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return
+	}
+
+	defer resp.Body.Close()
+	defer io.Copy(io.Discard, resp.Body)
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		lr := io.LimitReader(resp.Body, 1<<20) // 1MiB limit
+		errMsg, _ := io.ReadAll(lr)
+		return "", fmt.Errorf("HTTP error: %s (status: %d)", string(errMsg), resp.StatusCode)
+	}
+
+	return resp.Header.Get("ETag"), nil
+}
+
+// Delete deletes a file or a directory.
+func (rc *renterdClient) Delete(ctx context.Context, bucket, path string, batch bool) (err error) {
+	path = strings.ReplaceAll(path, "\\", "/") // Replace Windows formatting with the unified one
+	if batch {
+		err = rc.doRequest(ctx, "POST", "/api/worker/objects/remove", api.ObjectsRemoveRequest{
+			Bucket: bucket,
+			Prefix: "/" + path + "/",
+		}, nil)
+	} else {
+		values := make(url.Values)
+		values.Set("bucket", bucket)
+		err = rc.doRequest(ctx, "DELETE", fmt.Sprintf("/api/worker/object/%s?"+values.Encode(), path), nil, nil)
+	}
+	return
+}
+
+// MakeDirectory creates a new directory in the specified path.
+func (rc *renterdClient) MakeDirectory(ctx context.Context, bucket, path string) error {
+	path = strings.ReplaceAll(path, "\\", "/") // Replace Windows formatting with the unified one
+	path = api.ObjectKeyEscape(path)
+	path += "/"
+	values := make(url.Values)
+	values.Set("bucket", bucket)
+	return rc.doRequest(ctx, "PUT", fmt.Sprintf("/api/worker/object/%s?"+values.Encode(), path), nil, nil)
+}
+
+// Rename renames a file or a directory.
+func (rc *renterdClient) Rename(ctx context.Context, bucket, oldName, newName string, isDir, force bool) error {
+	mode := api.ObjectsRenameModeSingle
+	if isDir {
+		oldName += "/"
+		newName += "/"
+		mode = api.ObjectsRenameModeMulti
+	}
+	return rc.doRequest(ctx, "POST", "/api/bus/objects/rename", api.ObjectsRenameRequest{
+		Bucket: bucket,
+		Force:  force,
+		From:   "/" + oldName,
+		To:     "/" + newName,
+		Mode:   mode,
+	}, nil)
+}

--- a/client/renterd.go
+++ b/client/renterd.go
@@ -347,7 +347,7 @@ func (rc *renterdClient) Read(ctx context.Context, bucket, path string, offset, 
 }
 
 // StartUpload initiates a multipart upload.
-func (rc *renterdClient) StartUpload(ctx context.Context, bucket, path string) (uploadID []byte, err error) {
+func (rc *renterdClient) StartUpload(ctx context.Context, bucket, path string) (uploadID string, err error) {
 	if strings.HasSuffix(path, ":Zone.Identifier") { // Don't upload Windows' zone identifier files
 		return
 	}
@@ -359,11 +359,11 @@ func (rc *renterdClient) StartUpload(ctx context.Context, bucket, path string) (
 	}, &resp); err != nil {
 		return
 	}
-	return []byte(resp.UploadID), nil
+	return resp.UploadID, nil
 }
 
 // AbortUpload aborts an initiated multipart upload.
-func (rc *renterdClient) AbortUpload(ctx context.Context, bucket, path string, uploadID []byte) (err error) {
+func (rc *renterdClient) AbortUpload(ctx context.Context, bucket, path string, uploadID string) (err error) {
 	if strings.HasSuffix(path, ":Zone.Identifier") { // Don't upload Windows' zone identifier files
 		return
 	}
@@ -371,13 +371,13 @@ func (rc *renterdClient) AbortUpload(ctx context.Context, bucket, path string, u
 	err = rc.doRequest(ctx, "POST", "/api/bus/multipart/abort", api.MultipartAbortRequest{
 		Bucket:   bucket,
 		Key:      "/" + path,
-		UploadID: string(uploadID),
+		UploadID: uploadID,
 	}, nil)
 	return
 }
 
 // FinishUpload completes a multipart upload.
-func (rc *renterdClient) FinishUpload(ctx context.Context, bucket, path string, uploadID []byte, parts []api.MultipartCompletedPart) error {
+func (rc *renterdClient) FinishUpload(ctx context.Context, bucket, path string, uploadID string, parts []api.MultipartCompletedPart) error {
 	if strings.HasSuffix(path, ":Zone.Identifier") { // Don't upload Windows' zone identifier files
 		return nil
 	}
@@ -389,13 +389,13 @@ func (rc *renterdClient) FinishUpload(ctx context.Context, bucket, path string, 
 	return rc.doRequest(ctx, "POST", "/api/bus/multipart/complete", api.MultipartCompleteRequest{
 		Bucket:   bucket,
 		Key:      "/" + path,
-		UploadID: string(uploadID),
+		UploadID: uploadID,
 		Parts:    parts,
 	}, &resp)
 }
 
 // Write uploads the provided chunk of data to the Sia network.
-func (rc *renterdClient) Write(ctx context.Context, r io.Reader, bucket, path string, uploadID []byte, partNumber int, offset, length uint64) (eTag string, err error) {
+func (rc *renterdClient) Write(ctx context.Context, r io.Reader, bucket, path string, uploadID string, partNumber int, offset, length uint64) (eTag string, err error) {
 	if strings.HasSuffix(path, ":Zone.Identifier") { // Don't upload Windows' zone identifier files
 		return
 	}
@@ -403,7 +403,7 @@ func (rc *renterdClient) Write(ctx context.Context, r io.Reader, bucket, path st
 	path = api.ObjectKeyEscape(path)
 	values := make(url.Values)
 	values.Set("bucket", bucket)
-	values.Set("uploadid", string(uploadID))
+	values.Set("uploadid", uploadID)
 	values.Set("partnumber", fmt.Sprint(partNumber))
 
 	off := int(offset)

--- a/conn.go
+++ b/conn.go
@@ -22,7 +22,6 @@ import (
 	"github.com/mike76-dev/siasmb/utils"
 	"github.com/oiweiwei/go-msrpc/msrpc/lsat/lsarpc/v0"
 	"github.com/oiweiwei/go-msrpc/ndr"
-	"go.sia.tech/renterd/v2/api"
 )
 
 const (
@@ -719,6 +718,11 @@ func (c *connection) processRequest(req *smb2.Request) (smb2.GenericResponse, *s
 		}
 
 		path := strings.ReplaceAll(cr.Filename(), "\\", "/")
+		if strings.HasPrefix(path, ".") { // Hidden files of any sort are not supported
+			resp := smb2.NewErrorResponse(cr, smb2.STATUS_NOT_SUPPORTED, 0, nil)
+			return resp, ss, nil
+		}
+
 		co := cr.CreateOptions()
 		if co&smb2.FILE_DELETE_ON_CLOSE > 0 && (tc.maximalAccess&(smb2.DELETE|smb2.GENERIC_ALL|smb2.GENERIC_EXECUTE|smb2.GENERIC_READ|smb2.GENERIC_WRITE) == 0) {
 			resp := smb2.NewErrorResponse(cr, smb2.STATUS_ACCESS_DENIED, 0, nil)
@@ -997,36 +1001,9 @@ func (c *connection) processRequest(req *smb2.Request) (smb2.GenericResponse, *s
 		}
 
 		if op.pendingUpload != nil { // This SMB2_CLOSE request is a sign for us to flush any active multipart upload
-			op.pendingUpload.mu.Lock()
-			pending := len(op.pendingUpload.pending)
-			op.pendingUpload.mu.Unlock()
-			if pending == 0 {
-				err := op.treeConnect.share.client.FinishUpload(
-					op.ctx,
-					op.treeConnect.share.bucket,
-					op.pathName,
-					op.pendingUpload.uploadID,
-					op.pendingUpload.parts,
-				)
-				if err != nil {
-					log.Println("Error completing write:", err)
-				} else {
-					op.size = op.pendingUpload.totalSize
-					op.allocated = op.pendingUpload.totalSize
-					op.pendingUpload = nil
-					tc.mu.Lock()
-					delete(tc.persistedOpens, op.pathName)
-					tc.mu.Unlock()
-				}
-			} else {
-				if err := op.treeConnect.share.client.AbortUpload(
-					op.ctx,
-					op.treeConnect.share.bucket,
-					op.pathName,
-					op.pendingUpload.uploadID,
-				); err != nil {
-					log.Println("Error aborting write:", err)
-				}
+			if err := op.flush(); err != nil {
+				op.cancelUpload()
+				log.Println("Error completing write:", err)
 			}
 		}
 
@@ -1254,15 +1231,6 @@ func (c *connection) processRequest(req *smb2.Request) (smb2.GenericResponse, *s
 			return resp, nil, nil
 		}
 
-		ss.mu.Lock()
-		tc, found := ss.treeConnectTable[wr.Header().TreeID()]
-		ss.mu.Unlock()
-
-		if !found {
-			resp := smb2.NewErrorResponse(wr, smb2.STATUS_INVALID_PARAMETER, 0, nil)
-			return resp, ss, nil
-		}
-
 		ss.idleTime = time.Now()
 		length := uint64(len(wr.Buffer()))
 		if length > c.maxWriteSize {
@@ -1321,17 +1289,6 @@ func (c *connection) processRequest(req *smb2.Request) (smb2.GenericResponse, *s
 			return resp, ss, nil
 		}
 
-		// Initiate a multipart upload if it hasn't been done yet.
-		if op.pendingUpload == nil {
-			id, err := tc.share.client.StartUpload(op.ctx, tc.share.bucket, op.pathName)
-			if err != nil {
-				resp := smb2.NewErrorResponse(wr, smb2.STATUS_DATA_ERROR, 0, nil)
-				return resp, ss, nil
-			}
-
-			op.pendingUpload = &upload{uploadID: id, pending: make(map[uint64]*uploadChunk)}
-		}
-
 		// An SMB2_WRITE request can take long enough, especially on the Sia network, for the client
 		// to drop the connection. We send an interim response and process the request asynchronously
 		// to prevent that.
@@ -1349,111 +1306,28 @@ func (c *connection) processRequest(req *smb2.Request) (smb2.GenericResponse, *s
 		resp.Header().ClearFlag(smb2.FLAGS_SIGNED)
 		resp.Header()[len(resp.Header())-1] = 0x21
 
+		op.mu.Lock()
+		op.inflight++
+		op.mu.Unlock()
 		go func() {
+			defer func() {
+				op.mu.Lock()
+				op.inflight--
+				op.cond.Broadcast()
+				op.mu.Unlock()
+			}()
 			var resp smb2.GenericResponse
-			if op.pendingUpload == nil { // Should not happen
-				resp = smb2.NewErrorResponse(wr, smb2.STATUS_NOT_SUPPORTED, 0, nil)
-			} else {
-				offset := wr.Offset()
-				data := append([]byte{}, wr.Buffer()...)
-				op.pendingUpload.mu.Lock()
-				op.pendingUpload.pending[offset] = &uploadChunk{offset, data}
-				var err error
-				for {
-					select {
-					case <-op.ctx.Done():
-						return
-					default:
-					}
-					off := op.pendingUpload.nextOffset
-					chunk, ok := op.pendingUpload.pending[off]
-					if !ok {
-						break
-					}
-					op.pendingUpload.partCount++
-					var eTag string
-					eTag, err = tc.share.client.Write(
-						op.ctx,
-						bytes.NewReader(chunk.data),
-						tc.share.bucket,
-						op.pathName,
-						op.pendingUpload.uploadID,
-						op.pendingUpload.partCount,
-						chunk.offset,
-						uint64(len(chunk.data)),
-					)
-					if err != nil {
-						log.Println("Error writing data:", err)
-						resp = smb2.NewErrorResponse(wr, smb2.STATUS_DATA_ERROR, 0, nil)
-						break
-					} else {
-						op.pendingUpload.parts = append(op.pendingUpload.parts, api.MultipartCompletedPart{
-							PartNumber: op.pendingUpload.partCount,
-							ETag:       eTag,
-						})
-						op.pendingUpload.totalSize += uint64(len(chunk.data))
-						op.pendingUpload.nextOffset += uint64(len(chunk.data))
-						delete(op.pendingUpload.pending, chunk.offset)
-					}
-				}
-				size := op.pendingUpload.totalSize
-				if err == nil {
-					// If we know the file size, and if all parts have been uploaded, flush the upload.
-					if ((op.size > 0 && size >= op.size) || (op.allocated > 0 && size >= op.allocated)) && len(op.pendingUpload.pending) == 0 {
-						err = tc.share.client.FinishUpload(
-							op.ctx,
-							tc.share.bucket,
-							op.pathName,
-							op.pendingUpload.uploadID,
-							op.pendingUpload.parts,
-						)
-						if err != nil {
-							log.Println("Error completing write:", err)
-							resp = smb2.NewErrorResponse(wr, smb2.STATUS_DATA_ERROR, 0, nil)
-						} else {
-							op.size = size
-							op.allocated = size
-							op.pendingUpload = nil
-							tc.mu.Lock()
-							delete(tc.persistedOpens, op.pathName)
-							tc.mu.Unlock()
-						}
-					} else {
-						// If we don't know the file size, wait 10 minutes, then flush anyway.
-						size := op.pendingUpload.totalSize
-						go func(size uint64) {
-							<-time.After(10 * time.Minute)
-							if op != nil && op.pendingUpload != nil && op.pendingUpload.totalSize == size {
-								err = op.treeConnect.share.client.FinishUpload(
-									op.ctx,
-									op.treeConnect.share.bucket,
-									op.pathName,
-									op.pendingUpload.uploadID,
-									op.pendingUpload.parts,
-								)
-								if err != nil {
-									log.Println("Error completing write:", err)
-								} else {
-									op.size = size
-									op.allocated = size
-									op.pendingUpload = nil
-									tc.mu.Lock()
-									delete(tc.persistedOpens, op.pathName)
-									tc.mu.Unlock()
-								}
-							}
-						}(size)
-					}
 
-					resp = &smb2.WriteResponse{}
-					resp.FromRequest(wr)
-					resp.(*smb2.WriteResponse).Generate(uint32(len(wr.Buffer())))
-					resp.Header().SetAsyncID(asyncID)
-					resp.Header().SetFlag(smb2.FLAGS_ASYNC_COMMAND)
-				}
-				if op.pendingUpload != nil {
-					op.pendingUpload.mu.Unlock()
-				}
+			if err := op.write(wr.Offset(), wr.Buffer()); err != nil {
+				op.cancelUpload()
+				log.Println("Error writing data:", err)
+				resp = smb2.NewErrorResponse(wr, smb2.STATUS_DATA_ERROR, 0, nil)
+			} else {
+				resp = &smb2.WriteResponse{}
+				resp.FromRequest(wr)
+				resp.(*smb2.WriteResponse).Generate(uint32(len(wr.Buffer())))
+				resp.Header().SetAsyncID(asyncID)
+				resp.Header().SetFlag(smb2.FLAGS_ASYNC_COMMAND)
 			}
 
 			c.mu.Lock()
@@ -2151,30 +2025,10 @@ func (c *connection) processRequest(req *smb2.Request) (smb2.GenericResponse, *s
 					return resp, ss, nil
 				}
 
-				// Some clients set the EoF position of the file to indicate that it has been uploaded.
 				size := binary.LittleEndian.Uint64(sir.Buffer())
-				if op.pendingUpload != nil {
-					err := tc.share.client.FinishUpload(
-						op.ctx,
-						tc.share.bucket,
-						op.pathName,
-						op.pendingUpload.uploadID,
-						op.pendingUpload.parts,
-					)
-					if err != nil {
-						log.Println("Error completing write:", err)
-						resp := smb2.NewErrorResponse(sir, smb2.STATUS_DATA_ERROR, 0, nil)
-						return resp, ss, nil
-					} else {
-						op.pendingUpload = nil
-						tc.mu.Lock()
-						delete(tc.persistedOpens, op.pathName)
-						tc.mu.Unlock()
-					}
-
-					op.size = size
-					op.allocated = size
-				}
+				op.mu.Lock()
+				op.allocated = size
+				op.mu.Unlock()
 
 			case smb2.FileBasicInformation:
 				if op.grantedAccess&smb2.FILE_WRITE_ATTRIBUTES == 0 {
@@ -2207,31 +2061,6 @@ func (c *connection) processRequest(req *smb2.Request) (smb2.GenericResponse, *s
 
 				if fbi.FileAttributes != 0 {
 					op.fileAttributes = fbi.FileAttributes
-				}
-
-				// Some clients modify the FileBasicInfo to indicate that the file has been uploaded.
-				if op.pendingUpload != nil {
-					size := op.pendingUpload.totalSize
-					err := tc.share.client.FinishUpload(
-						op.ctx,
-						tc.share.bucket,
-						op.pathName,
-						op.pendingUpload.uploadID,
-						op.pendingUpload.parts,
-					)
-					if err != nil {
-						log.Println("Error completing write:", err)
-						resp := smb2.NewErrorResponse(sir, smb2.STATUS_DATA_ERROR, 0, nil)
-						return resp, ss, nil
-					} else {
-						op.pendingUpload = nil
-						tc.mu.Lock()
-						delete(tc.persistedOpens, op.pathName)
-						tc.mu.Unlock()
-					}
-
-					op.size = size
-					op.allocated = size
 				}
 
 			case smb2.FileDispositionInformation:
@@ -2474,6 +2303,9 @@ func (c *connection) cancelRequest(req *smb2.Request) error {
 	} else {
 		mid := cr.Header().MessageID()
 		for _, r := range c.asyncCommandList {
+			if r == nil {
+				continue
+			}
 			if r.Header().MessageID() == mid {
 				target = r
 				found = true
@@ -2483,7 +2315,7 @@ func (c *connection) cancelRequest(req *smb2.Request) error {
 	}
 	c.mu.Unlock()
 
-	if !found {
+	if !found || target == nil {
 		return nil
 	}
 
@@ -2497,13 +2329,8 @@ func (c *connection) cancelRequest(req *smb2.Request) error {
 		ss.mu.Lock()
 		op, found = ss.openTable[fid]
 		ss.mu.Unlock()
-		if found && op.durableFileID == dfid && op.pendingUpload != nil {
-			tc := op.treeConnect
-			if err := tc.share.client.AbortUpload(op.ctx, tc.share.bucket, op.pathName, op.pendingUpload.uploadID); err != nil {
-				log.Println("Couldn't abort upload:", err)
-			} else {
-				op.pendingUpload = nil
-			}
+		if found && op.durableFileID == dfid {
+			op.cancelUpload()
 		}
 	}
 

--- a/conn.go
+++ b/conn.go
@@ -6,7 +6,6 @@ import (
 	"crypto/rand"
 	"crypto/sha512"
 	"encoding/binary"
-	"encoding/hex"
 	"errors"
 	"log"
 	"math"
@@ -15,6 +14,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/mike76-dev/siasmb/client"
 	"github.com/mike76-dev/siasmb/ntlm"
 	"github.com/mike76-dev/siasmb/rpc"
 	"github.com/mike76-dev/siasmb/smb2"
@@ -737,16 +737,15 @@ func (c *connection) processRequest(req *smb2.Request) (smb2.GenericResponse, *s
 		cr.SetCreateOptions(co)
 
 		ctx, cancel := context.WithCancel(context.Background())
-		var info api.ObjectMetadata
+		var info client.ObjectInfo
 		var result uint32
 		var restored bool
 		var op *open
 		if tc.share.name == "ipc$" { // A named pipe is being created
 			switch strings.ToLower(path) {
 			case "srvsvc", "lsarpc", "mdssvc":
-				info = api.ObjectMetadata{
-					Bucket: tc.share.bucket,
-					Key:    path,
+				info = client.ObjectInfo{
+					Key: path,
 				}
 				result = smb2.FILE_OPENED
 			default: // Other named pipes are not supported
@@ -768,7 +767,7 @@ func (c *connection) processRequest(req *smb2.Request) (smb2.GenericResponse, *s
 				return resp, ss, nil
 			}
 
-			info, err = tc.share.client.GetObjectInfo(ctx, tc.share.bucket, path)
+			info, err = tc.share.client.Object(ctx, tc.share.bucket, path)
 			if err != nil && errors.Is(err, context.DeadlineExceeded) {
 				cancel()
 				resp := smb2.NewErrorResponse(cr, smb2.STATUS_IO_TIMEOUT, 0, nil)
@@ -782,10 +781,10 @@ func (c *connection) processRequest(req *smb2.Request) (smb2.GenericResponse, *s
 					op, restored = tc.persistedOpens[path]
 					tc.mu.Unlock()
 					if !restored {
-						info = api.ObjectMetadata{
-							Bucket:  tc.share.bucket,
-							Key:     "/" + path,
-							ModTime: api.TimeRFC3339(time.Now()),
+						info = client.ObjectInfo{
+							Key:        "/" + path,
+							CreatedAt:  time.Now(),
+							ModifiedAt: time.Now(),
 						}
 						result = smb2.FILE_CREATED
 					} else {
@@ -811,10 +810,10 @@ func (c *connection) processRequest(req *smb2.Request) (smb2.GenericResponse, *s
 				}
 			case smb2.FILE_CREATE:
 				if err != nil {
-					info = api.ObjectMetadata{
-						Bucket:  tc.share.bucket,
-						Key:     "/" + path,
-						ModTime: api.TimeRFC3339(time.Now()),
+					info = client.ObjectInfo{
+						Key:        "/" + path,
+						CreatedAt:  time.Now(),
+						ModifiedAt: time.Now(),
 					}
 					result = smb2.FILE_CREATED
 					if cr.CreateOptions()&smb2.FILE_DIRECTORY_FILE > 0 { // Make a new directory
@@ -836,10 +835,10 @@ func (c *connection) processRequest(req *smb2.Request) (smb2.GenericResponse, *s
 					op, restored = tc.persistedOpens[path]
 					tc.mu.Unlock()
 					if !restored {
-						info = api.ObjectMetadata{
-							Bucket:  tc.share.bucket,
-							Key:     "/" + path,
-							ModTime: api.TimeRFC3339(time.Now()),
+						info = client.ObjectInfo{
+							Key:        "/" + path,
+							CreatedAt:  time.Now(),
+							ModifiedAt: time.Now(),
 						}
 						result = smb2.FILE_CREATED
 						if cr.CreateOptions()&smb2.FILE_DIRECTORY_FILE > 0 { // Make a new directory
@@ -877,10 +876,10 @@ func (c *connection) processRequest(req *smb2.Request) (smb2.GenericResponse, *s
 					op, restored = tc.persistedOpens[path]
 					tc.mu.Unlock()
 					if !restored {
-						info = api.ObjectMetadata{
-							Bucket:  tc.share.bucket,
-							Key:     "/" + path,
-							ModTime: api.TimeRFC3339(time.Now()),
+						info = client.ObjectInfo{
+							Key:        "/" + path,
+							CreatedAt:  time.Now(),
+							ModifiedAt: time.Now(),
 						}
 						result = smb2.FILE_CREATED
 						if cr.CreateOptions()&smb2.FILE_DIRECTORY_FILE > 0 { // Make a new directory
@@ -1002,7 +1001,7 @@ func (c *connection) processRequest(req *smb2.Request) (smb2.GenericResponse, *s
 			pending := len(op.pendingUpload.pending)
 			op.pendingUpload.mu.Unlock()
 			if pending == 0 {
-				_, err := op.treeConnect.share.client.FinishUpload(
+				err := op.treeConnect.share.client.FinishUpload(
 					op.ctx,
 					op.treeConnect.share.bucket,
 					op.pathName,
@@ -1035,7 +1034,7 @@ func (c *connection) processRequest(req *smb2.Request) (smb2.GenericResponse, *s
 			tc.mu.Lock()
 			delete(tc.persistedOpens, op.pathName)
 			tc.mu.Unlock()
-			if err := tc.share.client.DeleteObject(op.ctx, tc.share.bucket, op.pathName, op.fileAttributes&smb2.FILE_ATTRIBUTE_DIRECTORY > 0); err != nil {
+			if err := tc.share.client.Delete(op.ctx, tc.share.bucket, op.pathName, op.fileAttributes&smb2.FILE_ATTRIBUTE_DIRECTORY > 0); err != nil {
 				log.Println("Error deleting object:", err)
 			}
 		}
@@ -1373,7 +1372,7 @@ func (c *connection) processRequest(req *smb2.Request) (smb2.GenericResponse, *s
 					}
 					op.pendingUpload.partCount++
 					var eTag string
-					eTag, err = tc.share.client.UploadPart(
+					eTag, err = tc.share.client.Write(
 						op.ctx,
 						bytes.NewReader(chunk.data),
 						tc.share.bucket,
@@ -1401,7 +1400,7 @@ func (c *connection) processRequest(req *smb2.Request) (smb2.GenericResponse, *s
 				if err == nil {
 					// If we know the file size, and if all parts have been uploaded, flush the upload.
 					if ((op.size > 0 && size >= op.size) || (op.allocated > 0 && size >= op.allocated)) && len(op.pendingUpload.pending) == 0 {
-						_, err = tc.share.client.FinishUpload(
+						err = tc.share.client.FinishUpload(
 							op.ctx,
 							tc.share.bucket,
 							op.pathName,
@@ -1425,7 +1424,7 @@ func (c *connection) processRequest(req *smb2.Request) (smb2.GenericResponse, *s
 						go func(size uint64) {
 							<-time.After(10 * time.Minute)
 							if op != nil && op.pendingUpload != nil && op.pendingUpload.totalSize == size {
-								_, err = op.treeConnect.share.client.FinishUpload(
+								err = op.treeConnect.share.client.FinishUpload(
 									op.ctx,
 									op.treeConnect.share.bucket,
 									op.pathName,
@@ -1868,7 +1867,7 @@ func (c *connection) processRequest(req *smb2.Request) (smb2.GenericResponse, *s
 
 			// Send as many search results as the buffer length allows.
 			var num int
-			buf, num = smb2.QueryDirectoryBuffer(qdr.FileInformationClass(), op.searchResults, qdr.OutputBufferLength(), single, false, smb2.FileInfo{}, smb2.FileInfo{})
+			buf, num = smb2.QueryDirectoryBuffer(qdr.FileInformationClass(), op.searchResults, qdr.OutputBufferLength(), single, false, client.FileInfo{}, client.FileInfo{})
 			op.searchResults = op.searchResults[num:]
 		} else {
 			// Run a new search.
@@ -1882,7 +1881,7 @@ func (c *connection) processRequest(req *smb2.Request) (smb2.GenericResponse, *s
 				return resp, ss, nil
 			}
 
-			dir, parentDir, err := tc.share.client.GetParentInfo(op.ctx, tc.share.bucket, searchPath)
+			dir, parentDir, err := tc.share.client.Parents(op.ctx, tc.share.bucket, searchPath)
 			if err != nil {
 				resp := smb2.NewErrorResponse(qdr, smb2.STATUS_BAD_NETWORK_NAME, 0, nil)
 				return resp, ss, nil
@@ -2046,42 +2045,19 @@ func (c *connection) processRequest(req *smb2.Request) (smb2.GenericResponse, *s
 			case smb2.FileFsAttributeInformation:
 				info = smb2.FileFsAttributeInfo()
 			case smb2.FileFsSizeInformation:
-				// To estimate the available storage on the Sia network is quite tricky.
-				// The workaround is to calculate the total remaining storage of all hosts
-				// that renterd has formed contracts with and give it as the available storage.
-				rs, err := tc.share.client.RemainingStorage(op.ctx)
+				si, err := tc.share.client.Storage(op.ctx, tc.share.bucket)
 				if err != nil {
-					log.Println("Error calculating remaining storage:", err)
+					log.Println("Error getting storage info:", err)
 				} else {
-					us, err := tc.share.client.UsedStorage(op.ctx, tc.share.bucket)
-					if err != nil {
-						log.Println("Error calculating used storage:", err)
-					} else {
-						red, err := tc.share.client.Redundancy(op.ctx)
-						if err != nil {
-							log.Println("Error getting redundancy settings:", err)
-						} else {
-							info = smb2.FileFsSizeInfo(rs+us, us, red)
-						}
-					}
+					info = smb2.FileFsSizeInfo(si)
 				}
 			case smb2.FileFsFullSizeInformation:
 				// Same as above.
-				rs, err := tc.share.client.RemainingStorage(op.ctx)
+				si, err := tc.share.client.Storage(op.ctx, tc.share.bucket)
 				if err != nil {
-					log.Println("Error calculating remaining storage:", err)
+					log.Println("Error getting storage info:", err)
 				} else {
-					us, err := tc.share.client.UsedStorage(op.ctx, tc.share.bucket)
-					if err != nil {
-						log.Println("Error calculating used storage:", err)
-					} else {
-						red, err := tc.share.client.Redundancy(op.ctx)
-						if err != nil {
-							log.Println("Error getting redundancy settings:", err)
-						} else {
-							info = smb2.FileFsFullSizeInfo(rs+us, us, red)
-						}
-					}
+					info = smb2.FileFsFullSizeInfo(si)
 				}
 			case smb2.FileFsDeviceInformation:
 				info = smb2.FileFsDeviceInfo()
@@ -2178,7 +2154,7 @@ func (c *connection) processRequest(req *smb2.Request) (smb2.GenericResponse, *s
 				// Some clients set the EoF position of the file to indicate that it has been uploaded.
 				size := binary.LittleEndian.Uint64(sir.Buffer())
 				if op.pendingUpload != nil {
-					eTag, err := tc.share.client.FinishUpload(
+					err := tc.share.client.FinishUpload(
 						op.ctx,
 						tc.share.bucket,
 						op.pathName,
@@ -2191,10 +2167,6 @@ func (c *connection) processRequest(req *smb2.Request) (smb2.GenericResponse, *s
 						return resp, ss, nil
 					} else {
 						op.pendingUpload = nil
-						buf, err := hex.DecodeString(eTag)
-						if err == nil && len(buf) >= 8 {
-							op.handle = binary.LittleEndian.Uint64(buf[:8])
-						}
 						tc.mu.Lock()
 						delete(tc.persistedOpens, op.pathName)
 						tc.mu.Unlock()
@@ -2240,7 +2212,7 @@ func (c *connection) processRequest(req *smb2.Request) (smb2.GenericResponse, *s
 				// Some clients modify the FileBasicInfo to indicate that the file has been uploaded.
 				if op.pendingUpload != nil {
 					size := op.pendingUpload.totalSize
-					eTag, err := tc.share.client.FinishUpload(
+					err := tc.share.client.FinishUpload(
 						op.ctx,
 						tc.share.bucket,
 						op.pathName,
@@ -2253,10 +2225,6 @@ func (c *connection) processRequest(req *smb2.Request) (smb2.GenericResponse, *s
 						return resp, ss, nil
 					} else {
 						op.pendingUpload = nil
-						buf, err := hex.DecodeString(eTag)
-						if err == nil && len(buf) >= 8 {
-							op.handle = binary.LittleEndian.Uint64(buf[:8])
-						}
 						tc.mu.Lock()
 						delete(tc.persistedOpens, op.pathName)
 						tc.mu.Unlock()
@@ -2310,7 +2278,7 @@ func (c *connection) processRequest(req *smb2.Request) (smb2.GenericResponse, *s
 					op.lastModified = time.Now()
 					tc.mu.Unlock()
 				} else {
-					if err := tc.share.client.RenameObject(
+					if err := tc.share.client.Rename(
 						op.ctx,
 						tc.share.bucket,
 						op.pathName,

--- a/main.go
+++ b/main.go
@@ -109,7 +109,10 @@ func main() {
 					// Reset the abuse protection.
 					server.mu.Lock()
 					server.connectionCount = make(map[string]int)
-					cl := server.connectionList
+					cl := make([]*connection, 0, len(server.connectionList))
+					for _, cn := range server.connectionList {
+						cl = append(cl, cn)
+					}
 					server.mu.Unlock()
 
 					// Drop unused connections.
@@ -124,11 +127,17 @@ func main() {
 
 		log.Println("Received interrupt signal, shutting down...")
 		server.mu.Lock()
-		defer server.mu.Unlock()
 		server.enabled = false
-		for addr, connection := range server.connectionList {
-			log.Printf("Closing connection from client %s\n", addr)
+		conns := make([]*connection, 0, len(server.connectionList))
+		for _, c := range server.connectionList {
+			conns = append(conns, c)
+		}
+		server.mu.Unlock()
+
+		for _, connection := range conns {
+			log.Printf("Closing connection from client %s\n", connection.clientName)
 			connection.conn.Close()
+			connection.once.Do(func() { close(connection.closeChan) })
 		}
 
 		apiSrv.Close()

--- a/main.go
+++ b/main.go
@@ -25,8 +25,6 @@ const version = "2.1.0-beta"
 
 var storesDir = flag.String("dir", ".", "directory for storing persistent data")
 
-var isIndexd bool // true if `indexd` mode is active
-
 func main() {
 	log.Printf("Starting SiaSMB v%s...\n", version)
 
@@ -44,7 +42,6 @@ func main() {
 	}
 
 	if cfg.Mode == "indexd" {
-		isIndexd = true
 		panic("indexd mode not supported yet")
 	} else if cfg.Mode != "renterd" {
 		panic("invalid mode")
@@ -86,7 +83,7 @@ func main() {
 	defer l.Close()
 
 	// Start the SMB server.
-	server := newServer(l, db, cfg.Debug)
+	server := newServer(l, db, cfg.Mode, cfg.Debug)
 	if smb2.MaxSupportedDialect != smb2.SMB_DIALECT_202 {
 		server.serverCapabilities |= smb2.GLOBAL_CAP_LARGE_MTU
 	}

--- a/open.go
+++ b/open.go
@@ -19,6 +19,7 @@ import (
 	"github.com/mike76-dev/siasmb/utils"
 	"github.com/oiweiwei/go-msrpc/msrpc/dtyp"
 	"github.com/oiweiwei/go-msrpc/msrpc/lsat/lsarpc/v0"
+	proto "go.sia.tech/core/rhp/v4"
 	"go.sia.tech/renterd/v2/api"
 	"golang.org/x/crypto/blake2b"
 )
@@ -36,12 +37,14 @@ type uploadChunk struct {
 
 // upload holds the information about an active multipart upload.
 type upload struct {
-	uploadID   []byte
+	uploadID   string
 	partCount  int
 	parts      []api.MultipartCompletedPart
 	totalSize  uint64
 	nextOffset uint64
 	pending    map[uint64]*uploadChunk
+	buf        []byte
+	bufOffset  uint64
 	mu         sync.Mutex
 }
 
@@ -101,6 +104,9 @@ type open struct {
 	srvsvcData []byte
 
 	mu sync.Mutex
+
+	inflight int
+	cond     *sync.Cond
 }
 
 // grantAccess returns true if the user's access rights are sufficient for performing the requested operation(s) on the file.
@@ -182,6 +188,7 @@ func (ss *session) registerOpen(cr smb2.CreateRequest, tc *treeConnect, info cli
 		chunkSize:      smb2.BytesPerSector * 4,
 		maxCacheSize:   4,
 	}
+	op.cond = sync.NewCond(&op.mu)
 
 	if isDir {
 		op.fileAttributes |= smb2.FILE_ATTRIBUTE_DIRECTORY
@@ -305,6 +312,7 @@ func (op *open) fileAllInformation() []byte {
 	var size, alloc uint64
 	var lc uint32
 	var pd bool
+	op.mu.Lock()
 	if strings.ToLower(op.fileName) == "srvsvc" {
 		alloc = 4096
 		lc = 1
@@ -341,6 +349,7 @@ func (op *open) fileAllInformation() []byte {
 			FileName: op.fileName,
 		},
 	}
+	op.mu.Unlock()
 	return fai.Encode()
 }
 
@@ -349,6 +358,7 @@ func (op *open) fileStandardInformation() []byte {
 	var size, alloc uint64
 	var lc uint32
 	var pd bool
+	op.mu.Lock()
 	if strings.ToLower(op.fileName) == "srvsvc" {
 		alloc = 4096
 		lc = 1
@@ -364,12 +374,14 @@ func (op *open) fileStandardInformation() []byte {
 		DeletePending:  pd,
 		Directory:      op.fileAttributes&smb2.FILE_ATTRIBUTE_DIRECTORY > 0,
 	}
+	op.mu.Unlock()
 	return fsi.Encode()
 }
 
 // fileNetworkOpenInformation genereates a FileNetworkOpenInfo structure.
 func (op *open) fileNetworkOpenInformation() []byte {
 	var size, alloc uint64
+	op.mu.Lock()
 	if op.fileAttributes&smb2.FILE_ATTRIBUTE_DIRECTORY == 0 {
 		size = op.size
 		alloc = op.allocated
@@ -383,14 +395,17 @@ func (op *open) fileNetworkOpenInformation() []byte {
 		EndOfFile:      size,
 		FileAttributes: op.fileAttributes,
 	}
+	op.mu.Unlock()
 	return fnoi.Encode()
 }
 
 // fileNormalizedNameInformation genereates a FileNormalizedNameInfo structure.
 func (op *open) fileNormalizedNameInformation() []byte {
+	op.mu.Lock()
 	fnni := smb2.FileNormalizedNameInfo{
 		Filename: op.pathName,
 	}
+	op.mu.Unlock()
 	return fnni.Encode()
 }
 
@@ -404,11 +419,13 @@ func (op *open) fileEaInformation() []byte {
 
 // fileStreamInformation generates a FileStreamInfo structure.
 func (op *open) fileStreamInformation() []byte {
+	op.mu.Lock()
 	fsi := smb2.FileStreamInfo{
 		StreamName:           "::$DATA",
 		StreamSize:           op.size,
 		StreamAllocationSize: op.allocated,
 	}
+	op.mu.Unlock()
 	return fsi.Encode()
 }
 
@@ -620,4 +637,201 @@ func (op *open) read(offset, length uint64) []byte {
 	}
 
 	return result
+}
+
+// startUpload initiates a multipart upload.
+func (op *open) startUpload() error {
+	op.mu.Lock()
+	defer op.mu.Unlock()
+
+	if op.pendingUpload != nil {
+		return nil
+	}
+
+	id, err := op.treeConnect.share.client.StartUpload(op.ctx, op.treeConnect.share.bucket, op.pathName)
+	if err != nil {
+		return err
+	}
+
+	op.pendingUpload = &upload{
+		uploadID:   id,
+		pending:    make(map[uint64]*uploadChunk),
+		nextOffset: 0,
+		bufOffset:  0,
+	}
+
+	return nil
+}
+
+// write buffers contiguous chunks of data and uploads them as needed.
+func (op *open) write(offset uint64, data []byte) error {
+	op.mu.Lock()
+	u := op.pendingUpload
+	op.mu.Unlock()
+
+	if u == nil {
+		if err := op.startUpload(); err != nil {
+			return err
+		}
+		op.mu.Lock()
+		u = op.pendingUpload
+		op.mu.Unlock()
+	}
+
+	u.mu.Lock()
+	defer u.mu.Unlock()
+
+	buf := make([]byte, len(data))
+	copy(buf, data)
+	u.pending[offset] = &uploadChunk{offset: offset, data: buf}
+
+	for {
+		ch, ok := u.pending[u.nextOffset]
+		if !ok {
+			break
+		}
+
+		if len(u.buf) == 0 {
+			u.bufOffset = u.nextOffset
+		}
+
+		u.buf = append(u.buf, ch.data...)
+		u.totalSize += uint64(len(ch.data))
+		u.nextOffset += uint64(len(ch.data))
+		delete(u.pending, ch.offset)
+	}
+
+	for uint64(len(u.buf)) >= proto.SectorSize {
+		sector := u.buf[:proto.SectorSize]
+		partOffset := u.bufOffset
+
+		u.partCount++
+		eTag, err := op.treeConnect.share.client.Write(
+			op.ctx,
+			bytes.NewReader(sector),
+			op.treeConnect.share.bucket,
+			op.pathName,
+			u.uploadID,
+			u.partCount,
+			partOffset,
+			proto.SectorSize,
+		)
+		if err != nil {
+			return err
+		}
+
+		u.parts = append(u.parts, api.MultipartCompletedPart{
+			PartNumber: u.partCount,
+			ETag:       eTag,
+		})
+
+		u.buf = u.buf[proto.SectorSize:]
+		u.bufOffset += proto.SectorSize
+	}
+
+	return nil
+}
+
+// flush uploads the remaining part and finalizes the upload.
+func (op *open) flush() error {
+	op.mu.Lock()
+	u := op.pendingUpload
+	for u != nil && op.inflight > 0 {
+		op.cond.Wait()
+		u = op.pendingUpload
+	}
+	op.mu.Unlock()
+
+	if u == nil {
+		return nil
+	}
+
+	u.mu.Lock()
+
+	for {
+		ch, ok := u.pending[u.nextOffset]
+		if !ok {
+			break
+		}
+		if len(u.buf) == 0 {
+			u.bufOffset = u.nextOffset
+		}
+		u.buf = append(u.buf, ch.data...)
+		u.totalSize += uint64(len(ch.data))
+		u.nextOffset += uint64(len(ch.data))
+		delete(u.pending, ch.offset)
+	}
+
+	if len(u.pending) != 0 {
+		u.mu.Unlock()
+		return errors.New("flush: non-contiguous pending write data")
+	}
+
+	if len(u.buf) > 0 {
+		u.partCount++
+		partOffset := u.bufOffset
+		partSize := uint64(len(u.buf))
+		eTag, err := op.treeConnect.share.client.Write(
+			op.ctx,
+			bytes.NewReader(u.buf),
+			op.treeConnect.share.bucket,
+			op.pathName,
+			u.uploadID,
+			u.partCount,
+			partOffset,
+			partSize,
+		)
+		if err != nil {
+			u.mu.Unlock()
+			return err
+		}
+
+		u.parts = append(u.parts, api.MultipartCompletedPart{
+			PartNumber: u.partCount,
+			ETag:       eTag,
+		})
+		u.buf = nil
+	}
+
+	uploadID := u.uploadID
+	parts := append([]api.MultipartCompletedPart(nil), u.parts...)
+	finalSize := u.totalSize
+	u.mu.Unlock()
+
+	if err := op.treeConnect.share.client.FinishUpload(op.ctx, op.treeConnect.share.bucket, op.pathName, uploadID, parts); err != nil {
+		return err
+	}
+
+	op.mu.Lock()
+	if op.pendingUpload == u {
+		op.size = finalSize
+		op.allocated = finalSize
+		op.pendingUpload = nil
+		op.lastModified = time.Now()
+	}
+	op.mu.Unlock()
+
+	op.treeConnect.mu.Lock()
+	delete(op.treeConnect.persistedOpens, op.pathName)
+	op.treeConnect.mu.Unlock()
+
+	return nil
+}
+
+// cancelUpload aborts the running upload.
+func (op *open) cancelUpload() {
+	op.mu.Lock()
+	u := op.pendingUpload
+	op.pendingUpload = nil
+	op.mu.Unlock()
+
+	if u == nil {
+		return
+	}
+
+	u.mu.Lock()
+	uploadID := u.uploadID
+	u.mu.Unlock()
+
+	_ = op.treeConnect.share.client.AbortUpload(op.ctx, op.treeConnect.share.bucket, op.pathName, uploadID)
 }

--- a/open.go
+++ b/open.go
@@ -12,6 +12,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/mike76-dev/siasmb/client"
 	"github.com/mike76-dev/siasmb/ntlm"
 	"github.com/mike76-dev/siasmb/rpc"
 	"github.com/mike76-dev/siasmb/smb2"
@@ -35,7 +36,7 @@ type uploadChunk struct {
 
 // upload holds the information about an active multipart upload.
 type upload struct {
-	uploadID   string
+	uploadID   []byte
 	partCount  int
 	parts      []api.MultipartCompletedPart
 	totalSize  uint64
@@ -63,9 +64,7 @@ type open struct {
 	createGuid                 [16]byte
 	applicationInstanceVersion [16]byte
 
-	// Since renterd has no idea about such attributes of the most operating systems as
-	// CreationTime, LastWriteTime, LastAccessTime, and ChangeTime, we can only operate
-	// with the lastModified property.
+	created      time.Time
 	lastModified time.Time
 
 	// size is how much space the file occupies.
@@ -81,7 +80,7 @@ type open struct {
 	// is a directory). It is needed, because it's common for the clients to send two consecutive
 	// SMB2_QUERY_DIRECTORY requests; the second one should be responded with the NO_MORE_FILES status.
 	lastSearch    string
-	searchResults []api.ObjectMetadata
+	searchResults []client.ObjectInfo
 
 	// if pendingUpload is not nil, it points to an active multipart upload.
 	pendingUpload *upload
@@ -139,7 +138,7 @@ func grantAccess(cr smb2.CreateRequest, tc *treeConnect, ss *session) bool {
 }
 
 // registerOpen creates a new Open object and registers it with the server.
-func (ss *session) registerOpen(cr smb2.CreateRequest, tc *treeConnect, info api.ObjectMetadata, ctx context.Context, cancel context.CancelFunc) *open {
+func (ss *session) registerOpen(cr smb2.CreateRequest, tc *treeConnect, info client.ObjectInfo, ctx context.Context, cancel context.CancelFunc) *open {
 	h, _ := blake2b.New256(nil)
 	h.Write([]byte(info.Key))
 	id := h.Sum(nil)
@@ -172,9 +171,10 @@ func (ss *session) registerOpen(cr smb2.CreateRequest, tc *treeConnect, info api
 		resumeKey:      id[:24],
 		createOptions:  cr.CreateOptions(),
 		fileAttributes: smb2.FILE_ATTRIBUTE_NORMAL,
-		lastModified:   time.Time(info.ModTime),
-		size:           uint64(info.Size),
-		allocated:      uint64(info.Size),
+		created:        info.CreatedAt,
+		lastModified:   info.ModifiedAt,
+		size:           info.Size,
+		allocated:      info.Size,
 		ctx:            ctx,
 		cancel:         cancel,
 		lsaFrames:      make(map[uint32]*rpc.Frame),
@@ -245,18 +245,18 @@ func (op *open) queryDirectory(pattern string) error {
 	}
 
 	share := op.treeConnect.share
-	objs, err := share.client.GetObjects(op.ctx, share.bucket, op.pathName+"/")
+	ois, err := share.client.List(op.ctx, share.bucket, op.pathName+"/")
 	if err != nil {
 		return err
 	}
 
-	var results []api.ObjectMetadata
+	var results []client.ObjectInfo
 	found := make(map[string]struct{})
-	for _, entry := range objs {
-		path, name, _ := utils.ExtractFilename(entry.Key)
+	for _, oi := range ois {
+		path, name, _ := utils.ExtractFilename(oi.Key)
 		match, _ := filepath.Match(pattern, name)
 		if match {
-			results = append(results, entry)
+			results = append(results, oi)
 			found[path] = struct{}{}
 		}
 	}
@@ -273,10 +273,11 @@ func (op *open) queryDirectory(pattern string) error {
 		}
 		match, _ := filepath.Match(pattern, utils.TrimPath(path))
 		if match {
-			results = append(results, api.ObjectMetadata{
-				Bucket:  tc.share.bucket,
-				Key:     "/" + path,
-				ModTime: api.TimeRFC3339(o.lastModified),
+			results = append(results, client.ObjectInfo{
+				Key:        "/" + path,
+				CreatedAt:  o.lastModified,
+				ModifiedAt: o.lastModified,
+				Size:       o.size,
 			})
 		}
 	}
@@ -434,18 +435,18 @@ func (op *open) newLSAFrame(ctx ntlm.SecurityContext) *rpc.Frame {
 // checkForChanges monitors if any significant changes have occurred in the specified directory.
 // Significant changes include: file names, sizes, modify times, or contents.
 func (op *open) checkForChanges(req smb2.ChangeNotifyRequest, stopChan chan struct{}) {
-	objs, err := op.treeConnect.share.client.GetObjects(op.ctx, op.treeConnect.share.bucket, op.pathName)
+	ois, err := op.treeConnect.share.client.List(op.ctx, op.treeConnect.share.bucket, op.pathName)
 	if err != nil {
 		return
 	}
 
 	found := make(map[string]struct{})
-	for _, entry := range objs {
-		if entry.Key == "" {
+	for _, oi := range ois {
+		if oi.Key == "" {
 			continue
 		}
-		if strings.HasPrefix(entry.Key[1:], op.pathName) {
-			found[entry.Key[1:]] = struct{}{}
+		if strings.HasPrefix(oi.Key[1:], op.pathName) {
+			found[oi.Key[1:]] = struct{}{}
 		}
 	}
 
@@ -455,15 +456,16 @@ func (op *open) checkForChanges(req smb2.ChangeNotifyRequest, stopChan chan stru
 		if _, ok := found[path]; ok {
 			continue
 		}
-		objs = append(objs, api.ObjectMetadata{
-			Bucket:  tc.share.bucket,
-			Key:     "/" + path,
-			ModTime: api.TimeRFC3339(o.lastModified),
+		ois = append(ois, client.ObjectInfo{
+			Key:        "/" + path,
+			CreatedAt:  o.lastModified,
+			ModifiedAt: o.lastModified,
+			Size:       o.size,
 		})
 	}
 	tc.mu.Unlock()
 
-	snapshot := makeSnapshot(objs)
+	snapshot := makeSnapshot(ois)
 	for {
 		select {
 		case <-stopChan: // Execution terminated
@@ -471,18 +473,18 @@ func (op *open) checkForChanges(req smb2.ChangeNotifyRequest, stopChan chan stru
 		case <-time.After(15 * time.Second): // Check every 15 seconds
 		}
 
-		objs, err := op.treeConnect.share.client.GetObjects(op.ctx, op.treeConnect.share.bucket, op.pathName)
+		ois, err := op.treeConnect.share.client.List(op.ctx, op.treeConnect.share.bucket, op.pathName)
 		if err != nil {
 			continue
 		}
 
 		found := make(map[string]struct{})
-		for _, entry := range objs {
-			if entry.Key == "" {
+		for _, oi := range ois {
+			if oi.Key == "" {
 				continue
 			}
-			if strings.HasPrefix(entry.Key[1:], op.pathName) {
-				found[entry.Key[1:]] = struct{}{}
+			if strings.HasPrefix(oi.Key[1:], op.pathName) {
+				found[oi.Key[1:]] = struct{}{}
 			}
 		}
 
@@ -492,15 +494,16 @@ func (op *open) checkForChanges(req smb2.ChangeNotifyRequest, stopChan chan stru
 			if _, ok := found[path]; ok {
 				continue
 			}
-			objs = append(objs, api.ObjectMetadata{
-				Bucket:  tc.share.bucket,
-				Key:     "/" + path,
-				ModTime: api.TimeRFC3339(o.lastModified),
+			ois = append(ois, client.ObjectInfo{
+				Key:        "/" + path,
+				CreatedAt:  o.lastModified,
+				ModifiedAt: o.lastModified,
+				Size:       o.size,
 			})
 		}
 		tc.mu.Unlock()
 
-		newSnapshot := makeSnapshot(objs)
+		newSnapshot := makeSnapshot(ois)
 		if !bytes.Equal(newSnapshot, snapshot) {
 			// Normally, the server should monitor the changes according to the filter specified in each
 			// SMB2_CHANGE_NOTIFY request. If the WATCH_TREE flag is set, the server should also monitor
@@ -520,17 +523,17 @@ func (op *open) checkForChanges(req smb2.ChangeNotifyRequest, stopChan chan stru
 }
 
 // makeSnapshot takes a snapshot of the directory.
-func makeSnapshot(entries []api.ObjectMetadata) []byte {
+func makeSnapshot(ois []client.ObjectInfo) []byte {
 	h, err := blake2b.New256(nil)
 	if err != nil {
 		return nil
 	}
 
-	for _, entry := range entries {
-		h.Write([]byte(entry.ETag))
-		h.Write([]byte(entry.ModTime.String()))
-		h.Write([]byte(entry.Key))
-		h.Write(binary.LittleEndian.AppendUint64(nil, uint64(entry.Size)))
+	for _, oi := range ois {
+		h.Write([]byte(oi.Key))
+		h.Write([]byte(oi.CreatedAt.String()))
+		h.Write([]byte(oi.ModifiedAt.String()))
+		h.Write(binary.LittleEndian.AppendUint64(nil, oi.Size))
 	}
 
 	return h.Sum(nil)
@@ -557,7 +560,7 @@ func (op *open) getObjectID() []byte {
 func (op *open) read(offset, length uint64) []byte {
 	readData := func(o, l uint64) ([]byte, error) {
 		var buf bytes.Buffer
-		err := op.treeConnect.share.client.ReadObject(op.ctx, op.treeConnect.share.bucket, op.pathName, o, l, &buf)
+		err := op.treeConnect.share.client.Read(op.ctx, op.treeConnect.share.bucket, op.pathName, o, l, &buf)
 		if err != nil {
 			return nil, err
 		}

--- a/server.go
+++ b/server.go
@@ -58,6 +58,7 @@ var (
 // server is the implementation of an SMB server.
 type server struct {
 	enabled                     bool
+	mode                        string
 	stats                       serverStats
 	shareList                   map[string]*share
 	globalOpenTable             map[uint64]*open
@@ -79,9 +80,10 @@ type server struct {
 }
 
 // newServer returns an initialized SMB server.
-func newServer(l net.Listener, st Store, debug bool) *server {
+func newServer(l net.Listener, st Store, mode string, debug bool) *server {
 	s := &server{
 		enabled:            true,
+		mode:               mode,
 		serverGuid:         uuid.New(),
 		shareList:          make(map[string]*share),
 		connectionList:     make(map[string]*connection),

--- a/share.go
+++ b/share.go
@@ -37,7 +37,7 @@ type share struct {
 	compressData    bool
 
 	// Auxiliary fields.
-	client    *client.Client
+	client    client.Client
 	bucket    string
 	createdAt time.Time
 	volumeID  uint64
@@ -46,7 +46,7 @@ type share struct {
 
 // registerShare adds a new share to the SMB server.
 func (s *server) registerShare(ss stores.Share, st Store) (*share, error) {
-	if isIndexd {
+	if s.mode == "indexd" {
 		return nil, nil // indexd is not supported yet.
 	}
 
@@ -64,12 +64,12 @@ func (s *server) registerShare(ss stores.Share, st Store) (*share, error) {
 		compressData:    s.compressionSupported,
 	}
 
-	sh.client = client.New(ss.ServerName, ss.Password)
+	sh.client = client.New(s.mode, ss.ServerName, ss.Password)
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
-	// Get the bucket information and test the share at the same time.
-	bucket, err := sh.client.GetBucket(ctx, ss.Bucket)
+	// Get the share information and test the share at the same time.
+	info, err := sh.client.Info(ctx, ss.Bucket)
 	if err != nil {
 		return nil, errShareUnavailable
 	}
@@ -100,8 +100,8 @@ func (s *server) registerShare(ss stores.Share, st Store) (*share, error) {
 
 	vid := make([]byte, 8)
 	rand.Read(vid[:])
-	sh.bucket = bucket.Name
-	sh.createdAt = time.Time(bucket.CreatedAt)
+	sh.bucket = info.Bucket
+	sh.createdAt = time.Time(info.CreatedAt)
 	sh.volumeID = binary.LittleEndian.Uint64(vid)
 	s.mu.Lock()
 	s.shareList[string(sh.id[:])+"/"+sh.name] = sh

--- a/smb2/query.go
+++ b/smb2/query.go
@@ -5,11 +5,11 @@ import (
 	"encoding/binary"
 	"time"
 
+	"github.com/mike76-dev/siasmb/client"
 	"github.com/mike76-dev/siasmb/ntlm"
 	"github.com/mike76-dev/siasmb/utils"
 	"github.com/oiweiwei/go-msrpc/msrpc/dtyp"
 	"github.com/oiweiwei/go-msrpc/ndr"
-	"go.sia.tech/renterd/v2/api"
 	"golang.org/x/crypto/blake2b"
 )
 
@@ -573,15 +573,8 @@ func (info fileIDAllExtdBothDirInfo) encode() []byte {
 	return buf
 }
 
-// FileInfo is a helper structure that combines the 64-bit and the 128-bit file IDs and the file creation time.
-type FileInfo struct {
-	ID64      uint64
-	ID        []byte
-	CreatedAt time.Time
-}
-
 // QueryDirectoryBuffer generates the query result depending on the provided parameters.
-func QueryDirectoryBuffer(class uint8, entries []api.ObjectMetadata, bufSize uint32, single, root bool, dir, parent FileInfo) (buf []byte, num int) {
+func QueryDirectoryBuffer(class uint8, entries []client.ObjectInfo, bufSize uint32, single, root bool, dir, parent client.FileInfo) (buf []byte, num int) {
 	var info []dirInfo
 	size := uint32(224) // The minimal size of the buffer for safety
 	if bufSize < size {
@@ -592,9 +585,9 @@ func QueryDirectoryBuffer(class uint8, entries []api.ObjectMetadata, bufSize uin
 		info = append(info,
 			dirInfo{
 				CreationTime:   dir.CreatedAt,
-				LastAccessTime: dir.CreatedAt,
-				LastWriteTime:  dir.CreatedAt,
-				ChangeTime:     dir.CreatedAt,
+				LastAccessTime: dir.ModifiedAt,
+				LastWriteTime:  dir.ModifiedAt,
+				ChangeTime:     dir.ModifiedAt,
 				FileAttributes: FILE_ATTRIBUTE_DIRECTORY,
 				FileID64:       dir.ID64,
 				FileID128:      dir.ID,
@@ -602,9 +595,9 @@ func QueryDirectoryBuffer(class uint8, entries []api.ObjectMetadata, bufSize uin
 			},
 			dirInfo{
 				CreationTime:   parent.CreatedAt,
-				LastAccessTime: parent.CreatedAt,
-				LastWriteTime:  parent.CreatedAt,
-				ChangeTime:     parent.CreatedAt,
+				LastAccessTime: parent.ModifiedAt,
+				LastWriteTime:  parent.ModifiedAt,
+				ChangeTime:     parent.ModifiedAt,
 				FileAttributes: FILE_ATTRIBUTE_DIRECTORY,
 				FileID64:       parent.ID64,
 				FileID128:      parent.ID,
@@ -623,10 +616,10 @@ func QueryDirectoryBuffer(class uint8, entries []api.ObjectMetadata, bufSize uin
 		}
 
 		di := dirInfo{
-			CreationTime:   time.Time(entry.ModTime),
-			LastAccessTime: time.Time(entry.ModTime),
-			LastWriteTime:  time.Time(entry.ModTime),
-			ChangeTime:     time.Time(entry.ModTime),
+			CreationTime:   entry.CreatedAt,
+			LastAccessTime: entry.ModifiedAt,
+			LastWriteTime:  entry.ModifiedAt,
+			ChangeTime:     entry.ModifiedAt,
 			FileName:       name,
 		}
 
@@ -634,8 +627,8 @@ func QueryDirectoryBuffer(class uint8, entries []api.ObjectMetadata, bufSize uin
 			di.FileAttributes = FILE_ATTRIBUTE_DIRECTORY
 		} else {
 			di.FileAttributes = FILE_ATTRIBUTE_NORMAL
-			di.EndOfFile = uint64(entry.Size)
-			di.AllocationSize = uint64(entry.Size)
+			di.EndOfFile = entry.Size
+			di.AllocationSize = entry.Size
 		}
 
 		hash := blake2b.Sum256([]byte(entry.Key))
@@ -862,31 +855,23 @@ func FileFsAttributeInfo() []byte {
 }
 
 // FileFsSizeInfo generates the output buffer for the FileFsSizeInformation info class.
-func FileFsSizeInfo(total, used uint64, redundancy api.RedundancySettings) []byte {
-	spu := uint32(1)
-	if redundancy.MinShards != 0 {
-		spu = uint32(redundancy.TotalShards / redundancy.MinShards)
-	}
-
+func FileFsSizeInfo(si client.StorageInfo) []byte {
+	spu := uint32(si.TotalShards / si.MinShards)
 	info := make([]byte, 24)
-	binary.LittleEndian.PutUint64(info[:8], total/BytesPerSector/uint64(spu))
-	binary.LittleEndian.PutUint64(info[8:16], (total-used)/BytesPerSector/uint64(spu))
+	binary.LittleEndian.PutUint64(info[:8], si.RemainingStorage+si.UsedStorage/BytesPerSector/uint64(spu))
+	binary.LittleEndian.PutUint64(info[8:16], si.RemainingStorage/BytesPerSector/uint64(spu))
 	binary.LittleEndian.PutUint32(info[16:20], spu)
 	binary.LittleEndian.PutUint32(info[20:24], uint32(BytesPerSector))
 	return info
 }
 
 // FileFsFullSizeInfo generates the output buffer for the FileFsFullSizeInformation info class.
-func FileFsFullSizeInfo(total, used uint64, redundancy api.RedundancySettings) []byte {
-	spu := uint32(1)
-	if redundancy.MinShards != 0 {
-		spu = uint32(redundancy.TotalShards / redundancy.MinShards)
-	}
-
+func FileFsFullSizeInfo(si client.StorageInfo) []byte {
+	spu := uint32(si.TotalShards / si.MinShards)
 	info := make([]byte, 32)
-	binary.LittleEndian.PutUint64(info[:8], total/BytesPerSector/uint64(spu))
-	binary.LittleEndian.PutUint64(info[8:16], (total-used)/BytesPerSector/uint64(spu))
-	binary.LittleEndian.PutUint64(info[16:24], (total-used)/BytesPerSector/uint64(spu))
+	binary.LittleEndian.PutUint64(info[:8], si.RemainingStorage+si.UsedStorage/BytesPerSector/uint64(spu))
+	binary.LittleEndian.PutUint64(info[8:16], si.RemainingStorage/BytesPerSector/uint64(spu))
+	binary.LittleEndian.PutUint64(info[16:24], si.RemainingStorage/BytesPerSector/uint64(spu))
 	binary.LittleEndian.PutUint32(info[24:28], spu)
 	binary.LittleEndian.PutUint32(info[28:32], uint32(BytesPerSector))
 	return info


### PR DESCRIPTION
This PR refactors the upload logic in such a way that the code buffers the incoming data chunks and uploads them once they reach the sector size. This should remove the cap on the file size with `renterd` (currently around 2.5GB).