### PR TITLE
Fix cut on Windows

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -48,6 +48,7 @@ type ObjectInfo struct {
 type Client interface {
 	Info(ctx context.Context, bucket string) (GeneralInfo, error)
 	Storage(ctx context.Context, bucket string) (StorageInfo, error)
+	IsEmpty(ctx context.Context, bucket, path string) (bool, error)
 	List(ctx context.Context, bucket, path string) ([]ObjectInfo, error)
 	Object(ctx context.Context, bucket, path string) (ObjectInfo, error)
 	Parents(ctx context.Context, bucket, path string) (currentDir, parentDir FileInfo, err error)

--- a/client/renterd.go
+++ b/client/renterd.go
@@ -131,6 +131,25 @@ func (rc *renterdClient) usedStorage(ctx context.Context, bucket string) (us uin
 	return osr.TotalUploadedSize, nil
 }
 
+// IsEmpty returns true if the directory contains at least one object.
+func (rc *renterdClient) IsEmpty(ctx context.Context, bucket, path string) (bool, error) {
+	values := url.Values{}
+	api.ListObjectOptions{
+		Bucket:    bucket,
+		Delimiter: "/",
+		Limit:     1,
+	}.Apply(values)
+	path = strings.ReplaceAll(path, "\\", "/") // Replace Windows formatting with the unified one
+	path = api.ObjectKeyEscape(path)
+	path += "?" + values.Encode()
+	var res api.ObjectsResponse
+	if err := rc.doRequest(ctx, "GET", fmt.Sprintf("/api/bus/objects/%s", path), nil, &res); err != nil {
+		return false, err
+	}
+
+	return len(res.Objects) == 0, nil
+}
+
 // List lists the contents of a directory.
 func (rc *renterdClient) List(ctx context.Context, bucket, path string) (ois []ObjectInfo, err error) {
 	values := url.Values{}

--- a/conn.go
+++ b/conn.go
@@ -2070,7 +2070,59 @@ func (c *connection) processRequest(req *smb2.Request) (smb2.GenericResponse, *s
 				}
 
 				if sir.Buffer()[0] == 1 { // Set the delete flag
-					op.createOptions |= smb2.FILE_DELETE_ON_CLOSE
+					if op.fileAttributes&smb2.FILE_ATTRIBUTE_DIRECTORY != 0 {
+						// We need to check if the directory is not empty. This can take some time.
+						aid := make([]byte, 8)
+						rand.Read(aid)
+						asyncID := binary.LittleEndian.Uint64(aid)
+						req.Header().SetAsyncID(asyncID)
+						req.Header().SetFlag(smb2.FLAGS_ASYNC_COMMAND)
+						c.mu.Lock()
+						c.asyncCommandList[asyncID] = req
+						ch := make(chan struct{})
+						c.stopChans[req.CancelRequestID()] = ch
+						c.mu.Unlock()
+
+						go func() {
+							var resp smb2.GenericResponse
+							empty, err := tc.share.client.IsEmpty(op.ctx, tc.share.bucket, op.pathName+"/")
+							if err != nil {
+								log.Printf("Error listing directory contents: %v", err)
+								resp = smb2.NewErrorResponse(sir, smb2.STATUS_NETWORK_NAME_DELETED, 0, nil)
+							} else {
+								if empty {
+									if op != nil {
+										op.createOptions |= smb2.FILE_DELETE_ON_CLOSE
+									}
+									resp = &smb2.SetInfoResponse{}
+									resp.FromRequest(sir)
+									resp.Header().SetAsyncID(asyncID)
+									resp.Header().SetFlag(smb2.FLAGS_ASYNC_COMMAND)
+								} else {
+									resp = smb2.NewErrorResponse(sir, smb2.STATUS_DIRECTORY_NOT_EMPTY, 0, nil)
+								}
+							}
+
+							c.mu.Lock()
+							delete(c.requestList, resp.Header().MessageID())
+							delete(c.asyncCommandList, asyncID)
+							c.mu.Unlock()
+
+							c.server.writeResponse(c, ss, resp)
+						}()
+
+						// Send an interim response.
+						resp := smb2.NewErrorResponse(sir, smb2.STATUS_PENDING, 0, nil)
+						resp.Header().SetAsyncID(asyncID)
+						resp.Header().SetFlag(smb2.FLAGS_ASYNC_COMMAND)
+						resp.Header().ClearFlag(smb2.FLAGS_RELATED_OPERATIONS)
+						resp.Header().ClearFlag(smb2.FLAGS_SIGNED)
+						resp.Header()[len(resp.Header())-1] = 0x21
+
+						return resp, ss, nil
+					} else {
+						op.createOptions |= smb2.FILE_DELETE_ON_CLOSE
+					}
 				}
 
 			case smb2.FileRenameInformation:

--- a/smb2/error.go
+++ b/smb2/error.go
@@ -37,6 +37,7 @@ const (
 	STATUS_NETWORK_NAME_DELETED                  = 0xc00000c9
 	STATUS_NETWORK_ACCESS_DENIED                 = 0xc00000ca
 	STATUS_BAD_NETWORK_NAME                      = 0xc00000cc
+	STATUS_DIRECTORY_NOT_EMPTY                   = 0xc0000101
 	STATUS_CANCELLED                             = 0xc0000120
 	STATUS_FILE_CLOSED                           = 0xc0000128
 	STATUS_USER_SESSION_DELETED                  = 0xc0000203


### PR DESCRIPTION
This PR fixes the cut-paste operation on Windows where a directory containing files was being moved from a remote storage elsewhere. Before the fix, such operation created an empty directory in the destination folder.