### PR TITLE
Refactor upload and download code

### DIFF
--- a/client/indexd.go
+++ b/client/indexd.go
@@ -4,12 +4,15 @@ import (
 	"bytes"
 	"context"
 	"encoding/binary"
+	"errors"
 	"fmt"
 	"io"
 	"log"
+	"time"
 
 	"github.com/mike76-dev/siasmb/stores"
 	proto "go.sia.tech/core/rhp/v4"
+	"go.sia.tech/core/types"
 	"go.sia.tech/indexd/slabs"
 	"go.sia.tech/renterd/v2/api"
 	sdk "go.sia.tech/siastorage"
@@ -23,17 +26,25 @@ type IndexdClient struct {
 	sdkClient    *sdk.SDK
 	dataShards   uint8
 	parityShards uint8
+	closeChan    chan struct{}
 }
 
 // NewIndexdClient returns an initialized IndexdClient.
 func NewIndexdClient(db *stores.Database, sdkClient *sdk.SDK, share string, dataShards, parityShards uint8) Client {
-	return &IndexdClient{
+	cc := make(chan struct{})
+	ic := &IndexdClient{
 		share:        share,
 		db:           db,
 		sdkClient:    sdkClient,
 		dataShards:   dataShards,
 		parityShards: parityShards,
+		closeChan:    cc,
 	}
+
+	// Start background upload thread.
+	go ic.processUploads(ic.closeChan)
+
+	return ic
 }
 
 // Info queries the general information about the share.
@@ -183,34 +194,41 @@ func (ic *IndexdClient) Parents(ctx context.Context, acc stores.Account, path st
 
 // Read downloads a file from the Sia network.
 func (ic *IndexdClient) Read(ctx context.Context, acc stores.Account, path string, offset, length uint64, buf io.Writer) (err error) {
-	slabs, partial, err := ic.db.GetMetadata(acc, ic.share, path)
+	slabs, err := ic.db.GetMetadata(acc, ic.share, path)
 	if err != nil {
 		return err
 	}
 
+	end := offset + length
+
 	for _, slab := range slabs {
-		if slab.At+slab.Length <= offset {
+		slabStart := slab.At
+		slabEnd := slab.At + slab.Length
+		if slabEnd <= offset {
 			continue
 		}
-
-		if slab.At >= offset+length {
+		if slabStart >= end {
 			break
 		}
 
-		obj, err := ic.sdkClient.Object(ctx, slab.Key)
-		if err != nil {
-			return err
-		}
+		readStart := max(offset, slabStart)
+		readEnd := min(end, slabEnd)
+		rangeOffset := slab.Offset + (readStart - slabStart)
+		rangeLength := readEnd - readStart
 
-		if err = ic.sdkClient.Download(ctx, buf, obj, sdk.WithDownloadRange(slab.Offset, slab.Length)); err != nil {
-			return err
-		}
-	}
+		if (slab.Key != types.Hash256{}) {
+			obj, err := ic.sdkClient.Object(ctx, slab.Key)
+			if err != nil {
+				return err
+			}
 
-	if partial.Data != nil && partial.At < offset+length && partial.At+uint64(len(partial.Data)) > offset {
-		_, err = io.Copy(buf, bytes.NewReader(partial.Data))
-		if err != nil {
-			return err
+			if err = ic.sdkClient.Download(ctx, buf, obj, sdk.WithDownloadRange(rangeOffset, rangeLength)); err != nil {
+				return err
+			}
+		} else if slab.Data != nil {
+			if _, err = io.Copy(buf, bytes.NewReader(slab.Data[readStart-slabStart:readEnd-slabStart])); err != nil {
+				return err
+			}
 		}
 	}
 
@@ -224,13 +242,13 @@ func (ic *IndexdClient) StartUpload(ctx context.Context, acc stores.Account, pat
 
 // AbortUpload aborts an initiated multipart upload.
 func (ic *IndexdClient) AbortUpload(ctx context.Context, _ string, uploadID string) (err error) {
-	parts, err := ic.db.ListUploadParts(uploadID)
+	slabs, err := ic.db.RemoveUpload(uploadID)
 	if err != nil {
-		return fmt.Errorf("couldn't retrieve upload parts: %v", err)
+		return fmt.Errorf("couldn't abort upload: %v", err)
 	}
 
-	for _, part := range parts {
-		if err := ic.sdkClient.DeleteObject(ctx, part); err != nil {
+	for _, key := range slabs {
+		if err := ic.sdkClient.DeleteObject(ctx, key); err != nil {
 			return fmt.Errorf("couldn't delete slab: %v", err)
 		}
 	}
@@ -239,7 +257,7 @@ func (ic *IndexdClient) AbortUpload(ctx context.Context, _ string, uploadID stri
 		return fmt.Errorf("couldn't prune slabs: %v", err)
 	}
 
-	return ic.db.RemoveUpload(uploadID)
+	return nil
 }
 
 // FinishUpload completes a multipart upload.
@@ -253,30 +271,16 @@ func (ic *IndexdClient) FinishUpload(ctx context.Context, path string, uploadID 
 
 // Write uploads the provided chunk of data to the Sia network.
 func (ic *IndexdClient) Write(ctx context.Context, r io.Reader, path string, uploadID string, partNumber int, offset, length uint64) (_ string, err error) {
-	if length >= proto.SectorSize*uint64(ic.dataShards) {
-		obj := sdk.NewEmptyObject()
-		err = ic.sdkClient.Upload(ctx, &obj, r, sdk.WithRedundancy(ic.dataShards, ic.parityShards))
-		if err != nil {
-			return "", fmt.Errorf("couldn't upload slab: %v", err)
-		}
+	buf, err := io.ReadAll(r)
+	if err != nil {
+		return "", fmt.Errorf("couldn't read data: %v", err)
+	}
+	if uint64(len(buf)) != length {
+		return "", fmt.Errorf("short read: expected %d bytes, got %d", length, len(buf))
+	}
 
-		if err := ic.sdkClient.PinObject(ctx, obj); err != nil {
-			return "", fmt.Errorf("couldn't pin slab: %v", err)
-		}
-
-		key := obj.ID()
-		if err = ic.db.AddPart(uploadID, partNumber, offset, 0, length, key[:]); err != nil {
-			return "", fmt.Errorf("couldn't add part to the database: %v", err)
-		}
-	} else {
-		buf, err := io.ReadAll(r)
-		if err != nil {
-			return "", fmt.Errorf("couldn't read data: %v", err)
-		}
-
-		if err = ic.db.AddPartialData(uploadID, partNumber, offset, buf); err != nil {
-			return "", fmt.Errorf("couldn't add partial data to the database: %v", err)
-		}
+	if err := ic.db.AddBufferedSlab(uploadID, offset, buf); err != nil {
+		return "", fmt.Errorf("couldn't add buffered slab to the database: %v", err)
 	}
 
 	return
@@ -353,5 +357,54 @@ func (ic *IndexdClient) DeleteAll(ctx context.Context) error {
 
 // Close closes the client and releases all resources.
 func (ic *IndexdClient) Close() error {
+	close(ic.closeChan)
 	return ic.sdkClient.Close()
+}
+
+// processUpload checks if there is a complete slab and uploads it.
+func (ic *IndexdClient) processUpload(ctx context.Context) error {
+	job, err := ic.db.ClaimUploadJob(uint64(ic.dataShards) * proto.SectorSize)
+	if err != nil {
+		return err
+	}
+
+	obj := sdk.NewEmptyObject()
+	if err := ic.sdkClient.Upload(ctx, &obj, bytes.NewReader(job.Data), sdk.WithRedundancy(ic.dataShards, ic.parityShards)); err != nil {
+		_ = ic.db.RequeueUploadJob(job.UploadID, job.MetadataID)
+		return fmt.Errorf("couldn't upload slab: %v", err)
+	}
+
+	if err := ic.sdkClient.PinObject(ctx, obj); err != nil {
+		_ = ic.db.RequeueUploadJob(job.UploadID, job.MetadataID)
+		return fmt.Errorf("couldn't pin slab: %v", err)
+	}
+
+	key := obj.ID()
+	if err := ic.db.CompleteUploadJob(job.MetadataID, job.BufferID, key); err != nil {
+		return fmt.Errorf("couldn't complete upload job: %v", err)
+	}
+
+	return nil
+}
+
+// processUploads runs the upload jobs in the background.
+func (ic *IndexdClient) processUploads(closeChan chan struct{}) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	for {
+		select {
+		case <-closeChan:
+			return
+		default:
+		}
+
+		if err := ic.processUpload(ctx); err != nil {
+			time.Sleep(time.Second)
+			if errors.Is(err, stores.ErrNoUploadJobs) {
+				continue
+			}
+			log.Printf("failed to run upload job: %v", err)
+		}
+	}
 }

--- a/init.sql
+++ b/init.sql
@@ -64,6 +64,7 @@ CREATE TABLE objects (
     account INT NOT NULL REFERENCES accounts(id) ON DELETE CASCADE,
     created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
     modified_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    temporary BOOLEAN NOT NULL DEFAULT FALSE,
     CONSTRAINT objects_share_fk FOREIGN KEY (share_name) REFERENCES shares(share_name) ON DELETE CASCADE,
     CONSTRAINT objects_directory_fk FOREIGN KEY (share_name, directory_id) REFERENCES directories(share_name, id) ON DELETE CASCADE,
     CONSTRAINT objects_unique_path UNIQUE (share_name, full_path),
@@ -73,9 +74,10 @@ CREATE TABLE objects (
 CREATE INDEX idx_directories_lookup_path ON directories (share_name, full_path);
 CREATE INDEX idx_directories_lookup_parent ON directories (parent_id);
 CREATE INDEX idx_directories_list ON directories (share_name, parent_id, name);
-CREATE INDEX idx_objects_lookup_path ON objects (share_name, full_path);
 CREATE INDEX idx_objects_list ON objects (share_name, directory_id, name);
 CREATE INDEX idx_objects_lookup_directory ON objects (directory_id);
+CREATE UNIQUE INDEX idx_objects_lookup_path ON objects (share_name, full_path) WHERE temporary = FALSE;
+CREATE UNIQUE INDEX idx_objects_lookup_entry ON objects (share_name, directory_id, name) WHERE temporary = FALSE;
 
 CREATE TABLE buffers (
     id BIGSERIAL PRIMARY KEY,
@@ -84,10 +86,19 @@ CREATE TABLE buffers (
     CONSTRAINT buffers_share_fk FOREIGN KEY (share_name) REFERENCES shares(share_name) ON DELETE CASCADE
 );
 
+CREATE TABLE uploads (
+    id BIGSERIAL PRIMARY KEY,
+    upload_id BYTEA NOT NULL UNIQUE,
+    object_id BIGINT NOT NULL REFERENCES objects(id) ON DELETE CASCADE,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    CONSTRAINT uploads_id_length CHECK (octet_length(upload_id) = 32)
+);
+
 CREATE TABLE metadata (
     id BIGSERIAL PRIMARY KEY,
     object_id BIGINT NOT NULL,
     obj_offset BIGINT NOT NULL,
+    upload_id BIGINT REFERENCES uploads(id) ON DELETE CASCADE,
     slab_key BYTEA,
     buffer_id BIGINT,
     data_offset BIGINT NOT NULL,
@@ -105,47 +116,12 @@ CREATE INDEX idx_metadata_object ON metadata (object_id);
 CREATE INDEX idx_metadata_offset ON metadata (object_id, obj_offset);
 CREATE INDEX idx_metadata_slab_key ON metadata (slab_key);
 CREATE INDEX idx_metadata_slab_key_offset ON metadata (slab_key, data_offset);
+CREATE INDEX idx_metadata_upload_id ON metadata (upload_id);
 CREATE UNIQUE INDEX idx_metadata_object_offset ON metadata (object_id, obj_offset);
 
-CREATE TABLE uploads (
+CREATE TABLE upload_jobs (
     id BIGSERIAL PRIMARY KEY,
-    upload_id BYTEA NOT NULL UNIQUE,
-    share_name TEXT NOT NULL,
-    directory_id BIGINT,
-    name TEXT NOT NULL,
-    full_path TEXT NOT NULL,
-    account INT NOT NULL REFERENCES accounts(id) ON DELETE CASCADE,
-    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
-    CONSTRAINT uploads_share_fk FOREIGN KEY (share_name) REFERENCES shares(share_name) ON DELETE CASCADE,
-    CONSTRAINT uploads_directory_fk FOREIGN KEY (share_name, directory_id) REFERENCES directories(share_name, id) ON DELETE CASCADE,
-    CONSTRAINT uploads_id_length CHECK (octet_length(upload_id) = 32),
-    CONSTRAINT uploads_unique_path UNIQUE (share_name, full_path)
+    upload_id BIGINT NOT NULL REFERENCES uploads(id) ON DELETE CASCADE,
+    metadata_id BIGINT NOT NULL UNIQUE REFERENCES metadata(id) ON DELETE CASCADE,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
 );
-
-CREATE TABLE parts (
-    id BIGSERIAL PRIMARY KEY,
-    upload_id BIGINT NOT NULL,
-    part_number INT NOT NULL,
-    obj_offset BIGINT NOT NULL,
-    slab_key BYTEA,
-    buffer_id BIGINT,
-    data_offset BIGINT NOT NULL,
-    data_length BIGINT NOT NULL,
-    CONSTRAINT parts_upload_fk FOREIGN KEY (upload_id) REFERENCES uploads(id) ON DELETE CASCADE,
-    CONSTRAINT parts_key_length CHECK (slab_key IS NULL OR octet_length(slab_key) = 32),
-    CONSTRAINT parts_unique_part UNIQUE (upload_id, obj_offset),
-    CONSTRAINT parts_unique_part_number UNIQUE (upload_id, part_number),
-    CONSTRAINT parts_buffer_fk FOREIGN KEY (buffer_id) REFERENCES buffers(id),
-    CONSTRAINT parts_storage_check CHECK (
-        (slab_key IS NOT NULL AND buffer_id IS NULL) OR
-        (slab_key IS NULL AND buffer_id IS NOT NULL)
-    )
-);
-
-CREATE INDEX idx_uploads_lookup_path ON uploads (share_name, full_path);
-CREATE INDEX idx_uploads_lookup_directory ON uploads (directory_id);
-CREATE INDEX idx_uploads_id ON uploads (upload_id);
-CREATE INDEX idx_uploads_account ON uploads (account);
-CREATE INDEX idx_parts_upload ON parts (upload_id);
-CREATE INDEX idx_parts_number ON parts (upload_id, part_number);
-CREATE UNIQUE INDEX idx_parts_upload_offset ON parts (upload_id, obj_offset);

--- a/stores/filesystem.go
+++ b/stores/filesystem.go
@@ -86,6 +86,7 @@ func (db *Database) ListObjects(acc Account, shareName, path string) (objects []
 			CROSS JOIN caller c
 			WHERE o.share_name = $1
 				AND o.directory_id IS NOT DISTINCT FROM $2
+				AND o.temporary = FALSE
 				AND (
 					o.account = c.id
 					OR (
@@ -124,6 +125,10 @@ func (db *Database) ListObjects(acc Account, shareName, path string) (objects []
 				return fmt.Errorf("failed to scan object: %v", err)
 			}
 			objects = append(objects, obj)
+		}
+
+		if rows.Err() != nil {
+			return fmt.Errorf("error iterating over objects: %v", rows.Err())
 		}
 
 		return nil
@@ -289,6 +294,7 @@ func (db *Database) Object(acc Account, shareName, path string) (object ObjectMe
 				CROSS JOIN caller c
 				WHERE o.share_name = $1
 					AND o.full_path = $2
+					AND o.temporary = FALSE
 					AND (
 						o.account = c.id
 						OR (
@@ -412,7 +418,94 @@ func (db *Database) RenameFile(acc Account, share string, oldPath, newPath strin
 	}
 
 	return db.txn(func(ctx context.Context, tx pgx.Tx) error {
-		const query = `
+		const collectQuery = `
+			WITH caller AS (
+				SELECT id, workgroup
+				FROM accounts
+				WHERE id = $6
+			),
+			src AS (
+				SELECT o.id
+				FROM objects o
+				CROSS JOIN caller c
+				WHERE o.share_name = $1
+					AND o.full_path = $2
+					AND o.temporary = FALSE
+					AND o.account = c.id
+			),
+			dst_parent AS (
+				SELECT d.id, d.full_path
+				FROM directories d
+				JOIN accounts owner ON owner.id = d.account
+				CROSS JOIN caller c
+				WHERE d.share_name = $1
+					AND d.full_path = $3
+					AND (
+						d.account = c.id
+						OR (d.private = FALSE AND owner.workgroup = c.workgroup)
+					)
+
+				UNION ALL
+
+				SELECT NULL::bigint, '/'
+				FROM caller
+				WHERE $3 = '/'
+			),
+			target AS (
+				SELECT
+					s.id AS src_id,
+					p.id AS new_parent_id,
+					$4::text AS new_name,
+					$5::text AS new_path
+				FROM src s
+				JOIN dst_parent p ON TRUE
+				WHERE $5 <> $2
+			),
+			check_no_dir_conflict AS (
+				SELECT 1
+				FROM target t
+				WHERE NOT EXISTS (
+					SELECT 1
+					FROM directories d
+					WHERE d.share_name = $1
+						AND d.full_path = t.new_path
+				)
+			),
+			doomed_target AS (
+				SELECT o.id
+				FROM objects o
+				JOIN target t ON o.full_path = t.new_path
+				WHERE o.share_name = $1
+					AND o.temporary = FALSE
+					AND $7::boolean
+			)
+			SELECT DISTINCT m.buffer_id
+			FROM doomed_target dt
+			JOIN check_no_dir_conflict c ON TRUE
+			JOIN metadata m ON m.object_id = dt.id
+			WHERE m.buffer_id IS NOT NULL
+		`
+
+		rows, err := tx.Query(ctx, collectQuery, share, oldPath, dir, name, newPath, acc.ID, force)
+		if err != nil {
+			return fmt.Errorf("failed to collect information for renaming file: %v", err)
+		}
+		var bids []uint64
+		for rows.Next() {
+			var bid uint64
+			if err := rows.Scan(&bid); err != nil {
+				rows.Close()
+				return fmt.Errorf("failed to scan buffer ID: %v", err)
+			}
+			bids = append(bids, bid)
+		}
+		if err := rows.Err(); err != nil {
+			rows.Close()
+			return fmt.Errorf("failed to iterate through buffer IDs: %v", err)
+		}
+		rows.Close()
+
+		const renameQuery = `
 			WITH caller AS (
 				SELECT id, workgroup
 				FROM accounts
@@ -421,10 +514,10 @@ func (db *Database) RenameFile(acc Account, share string, oldPath, newPath strin
 			src AS (
 				SELECT o.id, o.full_path
 				FROM objects o
-				JOIN accounts owner ON owner.id = o.account
 				CROSS JOIN caller c
 				WHERE o.share_name = $1
 					AND o.full_path = $2
+					AND o.temporary = FALSE
 					AND o.account = c.id
 			),
 			dst_parent AS (
@@ -468,9 +561,12 @@ func (db *Database) RenameFile(acc Account, share string, oldPath, newPath strin
 			delete_existing AS (
 				DELETE FROM objects o
 				USING target t
+				JOIN check_no_dir_conflict c ON TRUE
 				WHERE $7::boolean
 					AND o.share_name = $1
 					AND o.full_path = t.new_path
+					AND o.temporary = FALSE
+				RETURNING o.id
 			)
 			UPDATE objects o
 			SET
@@ -485,13 +581,27 @@ func (db *Database) RenameFile(acc Account, share string, oldPath, newPath strin
 		`
 
 		var id uint64
-		err := tx.QueryRow(ctx, query, share, oldPath, dir, name, newPath, acc.ID, force).Scan(&id)
-		if err != nil {
+		if err := tx.QueryRow(ctx, renameQuery, share, oldPath, dir, name, newPath, acc.ID, force).Scan(&id); err != nil {
 			if errors.Is(err, pgx.ErrNoRows) {
 				return ErrNotFound
 			}
 			return fmt.Errorf("failed to rename file: %v", err)
 		}
+
+		for _, bid := range bids {
+			if _, err := tx.Exec(ctx, `
+				DELETE FROM buffers b
+				WHERE b.id = $1
+					AND NOT EXISTS (
+						SELECT 1
+						FROM metadata m
+						WHERE m.buffer_id = b.id
+					)
+			`, bid); err != nil {
+				return fmt.Errorf("failed to delete orphaned buffer: %v", err)
+			}
+		}
+
 		return nil
 	})
 }
@@ -586,6 +696,7 @@ func (db *Database) RenameDirectory(acc Account, share string, oldPath, newPath 
 					AND o.share_name = $1
 					AND o.full_path LIKE t.old_path || '/%%'
 					AND o.account = c.id
+					AND o.temporary = FALSE
 			)
 			UPDATE directories d
 			SET
@@ -628,6 +739,7 @@ func (db *Database) DeleteFile(acc Account, share string, path string) error {
 				CROSS JOIN caller c
 				WHERE o.share_name = $1
 					AND o.full_path = $2
+					AND o.temporary = FALSE
 					AND (
 						o.account = c.id
 						OR (
@@ -698,6 +810,7 @@ func (db *Database) DeleteDirectory(acc Account, share string, path string) erro
 				JOIN src s ON TRUE
 				WHERE o.share_name = $1
 					AND o.full_path LIKE s.full_path || '/%%'
+					And o.temporary = FALSE
 			),
 			doomed_buffers AS (
 				SELECT DISTINCT m.buffer_id
@@ -710,6 +823,7 @@ func (db *Database) DeleteDirectory(acc Account, share string, path string) erro
 				USING src s
 				WHERE o.share_name = $1
 					AND o.full_path LIKE s.full_path || '/%%'
+					AND o.temporary = FALSE
 				RETURNING o.id
 			),
 			delete_dirs AS (

--- a/stores/upload.go
+++ b/stores/upload.go
@@ -20,6 +20,22 @@ type SlabSlice struct {
 	Data   []byte
 }
 
+// uploadJob represents a pending upload job that is being processed asynchronously.
+type UploadJob struct {
+	ID         uint64
+	UploadID   uint64
+	MetadataID uint64
+	ObjectID   uint64
+	BufferID   uint64
+	ObjOffset  uint64
+	DataOffset uint64
+	DataLength uint64
+	Data       []byte
+}
+
+// ErrNoUploadJobs is returned when there are no pending upload jobs available for processing.
+var ErrNoUploadJobs = errors.New("no upload jobs available")
+
 // CreateUpload creates a new upload entry in the database and returns the generated upload ID.
 func (db *Database) CreateUpload(acc Account, share, path string) (uploadID string, err error) {
 	path = normalizePath(path)
@@ -40,7 +56,7 @@ func (db *Database) CreateUpload(acc Account, share, path string) (uploadID stri
 				WHERE id = $3
 			),
 			parent AS (
-				SELECT d.id, d.full_path
+				SELECT d.id
 				FROM directories d
 				JOIN accounts owner ON owner.id = d.account
 				CROSS JOIN caller c
@@ -53,30 +69,57 @@ func (db *Database) CreateUpload(acc Account, share, path string) (uploadID stri
 
 				UNION ALL
 
-				SELECT NULL::bigint, '/'
+				SELECT NULL::bigint
 				FROM caller
 				WHERE $2 = '/'
+			),
+			no_existing_upload AS (
+				SELECT 1
+				FROM parent p
+				WHERE NOT EXISTS (
+					SELECT 1
+					FROM uploads u
+					JOIN objects o ON o.id = u.object_id
+					WHERE o.share_name = $1
+						AND o.full_path = $4
+				)
+			),
+			staging AS (
+				INSERT INTO objects (
+					share_name,
+					directory_id,
+					name,
+					full_path,
+					size,
+					account,
+					temporary
+				)
+				SELECT
+					$1,
+					p.id,
+					$5,
+					$4,
+					0,
+					$3,
+					TRUE
+				FROM parent p
+				JOIN no_existing_upload n ON TRUE
+				RETURNING id
 			)
-			INSERT INTO uploads (
-				upload_id,
-				share_name,
-				directory_id,
-				name,
-				full_path,
-				account
-			)
-			SELECT
-				$4,
-				$1,
-				p.id,
-				$5,
-				$6,
-				$3
-			FROM parent p
+			INSERT INTO uploads (upload_id, object_id)
+			SELECT $6, s.id
+			FROM staging s
+			RETURNING id
 		`
 
-		_, err = tx.Exec(ctx, query, share, dir, acc.ID, id, name, path)
-		return err
+		var uid uint64
+		if err = tx.QueryRow(ctx, query, share, dir, acc.ID, path, name, id).Scan(&uid); err != nil {
+			if errors.Is(err, pgx.ErrNoRows) {
+				return ErrNotFound
+			}
+			return fmt.Errorf("failed to create upload: %w", err)
+		}
+		return nil
 	})
 
 	if err != nil {
@@ -87,137 +130,118 @@ func (db *Database) CreateUpload(acc Account, share, path string) (uploadID stri
 
 // RemoveUpload deletes an upload entry from the database and removes any associated
 // buffers that are not referenced by other uploads or metadata entries.
-func (db *Database) RemoveUpload(uploadID string) error {
+func (db *Database) RemoveUpload(uploadID string) (slabs []types.Hash256, err error) {
 	id, err := hex.DecodeString(uploadID)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
-	return db.txn(func(ctx context.Context, tx pgx.Tx) error {
-		const query = `
-			WITH doomed_upload AS (
-				SELECT id
-				FROM uploads
-				WHERE upload_id = $1
-			),
-			doomed_buffers AS (
-				SELECT DISTINCT p.buffer_id
-				FROM parts p
-				JOIN doomed_upload u ON u.id = p.upload_id
-				WHERE p.buffer_id IS NOT NULL
-			),
-			deleted_upload AS (
-				DELETE FROM uploads u
-				USING doomed_upload d
-				WHERE u.id = d.id
-				RETURNING u.id
-			)
-			DELETE FROM buffers b
-			USING doomed_buffers db
-			WHERE b.id = db.buffer_id
-				AND NOT EXISTS (
-					SELECT 1 FROM parts p WHERE p.buffer_id = b.id
-				)
-				AND NOT EXISTS (
-					SELECT 1 FROM metadata m WHERE m.buffer_id = b.id
-				)
-		`
-
-		_, err := tx.Exec(ctx, query, id)
-		return err
-	})
-}
-
-// AddPartialData adds a new buffer entry for the provided data and
-// associates it with the given upload ID and part number.
-func (db *Database) AddPartialData(uploadID string, partNumber int, offset uint64, data []byte) error {
-	id, err := hex.DecodeString(uploadID)
-	if err != nil {
-		return err
-	}
-
-	return db.txn(func(ctx context.Context, tx pgx.Tx) error {
-		const bufQuery = `
-			INSERT INTO buffers (share_name, data)
-			SELECT u.share_name, $2
+	err = db.txn(func(ctx context.Context, tx pgx.Tx) error {
+		const lookup = `
+			SELECT u.id, u.object_id
 			FROM uploads u
+			JOIN objects o ON o.id = u.object_id
 			WHERE u.upload_id = $1
-			RETURNING id
+				AND o.temporary = TRUE
 		`
 
-		var bufferID uint64
-		if err := tx.QueryRow(ctx, bufQuery, id, data).Scan(&bufferID); err != nil {
-			return fmt.Errorf("couldn't parse buffer ID: %v", err)
+		var uid, soid uint64
+		if err := tx.QueryRow(ctx, lookup, id).Scan(&uid, &soid); err != nil {
+			if errors.Is(err, pgx.ErrNoRows) {
+				return ErrNotFound
+			}
+			return fmt.Errorf("failed to lookup upload: %w", err)
 		}
 
-		const partQuery = `
-			INSERT INTO parts (
-				upload_id,
-				part_number,
-				obj_offset,
-				buffer_id,
-				data_offset,
-				data_length
-			)
-			SELECT
-				u.id,
-				$2,
-				$3,
-				$4,
-				0,
-				$5
-			FROM uploads u
-			WHERE u.upload_id = $1
+		const collectBuffers = `
+			SELECT DISTINCT m.buffer_id
+			FROM metadata m
+			WHERE m.object_id = $1
+				AND m.buffer_id IS NOT NULL
 		`
 
-		_, err := tx.Exec(ctx, partQuery, id, partNumber, offset, bufferID, len(data))
+		rows, err := tx.Query(ctx, collectBuffers, soid)
 		if err != nil {
-			return fmt.Errorf("couldn't insert incomplete part: %v", err)
+			return fmt.Errorf("failed to collect buffers: %w", err)
 		}
+		var bids []uint64
+		for rows.Next() {
+			var bid uint64
+			if err := rows.Scan(&bid); err != nil {
+				rows.Close()
+				return fmt.Errorf("failed to scan buffer ID: %w", err)
+			}
+			bids = append(bids, bid)
+		}
+		if err := rows.Err(); err != nil {
+			rows.Close()
+			return fmt.Errorf("failed to iterate buffer IDs: %w", err)
+		}
+		rows.Close()
+
+		const collectSlabs = `
+			SELECT DISTINCT m.slab_key
+			FROM metadata m
+			WHERE m.object_id = $1
+				AND m.slab_key IS NOT NULL
+			ORDER BY m.slab_key
+		`
+
+		rows, err = tx.Query(ctx, collectSlabs, soid)
+		if err != nil {
+			return fmt.Errorf("failed to collect slab keys: %w", err)
+		}
+		for rows.Next() {
+			var raw []byte
+			if err := rows.Scan(&raw); err != nil {
+				rows.Close()
+				return fmt.Errorf("failed to scan slab key: %w", err)
+			}
+			if len(raw) != 32 {
+				rows.Close()
+				return fmt.Errorf("invalid slab key length: %d", len(raw))
+			}
+			var h types.Hash256
+			copy(h[:], raw)
+			slabs = append(slabs, h)
+		}
+		if err := rows.Err(); err != nil {
+			rows.Close()
+			return fmt.Errorf("failed to iterate slab keys: %w", err)
+		}
+		rows.Close()
+
+		if _, err := tx.Exec(ctx, `DELETE FROM uploads WHERE id = $1`, uid); err != nil {
+			return fmt.Errorf("failed to delete upload: %w", err)
+		}
+
+		if _, err := tx.Exec(ctx, `DELETE FROM objects WHERE id = $1`, soid); err != nil {
+			return fmt.Errorf("failed to delete temporary object: %w", err)
+		}
+
+		for _, id := range bids {
+			if _, err := tx.Exec(ctx, `
+				DELETE FROM buffers b
+				WHERE b.id = $1
+					AND NOT EXISTS (
+						SELECT 1
+						FROM metadata m
+						WHERE m.buffer_id = b.id
+					)
+			`, id); err != nil {
+				return fmt.Errorf("failed to delete orphaned buffer: %w", err)
+			}
+		}
+
 		return nil
 	})
+
+	return
 }
 
-// AddPart adds a new part entry for the provided slab key and
-// associates it with the given upload ID and part number.
-func (db *Database) AddPart(uploadID string, partNumber int, offset, dataOffset, dataLength uint64, slabKey []byte) error {
-	id, err := hex.DecodeString(uploadID)
-	if err != nil {
-		return err
-	}
-
-	return db.txn(func(ctx context.Context, tx pgx.Tx) error {
-		const query = `
-			INSERT INTO parts (
-				upload_id,
-				part_number,
-				obj_offset,
-				slab_key,
-				data_offset,
-				data_length
-			)
-			SELECT
-				u.id,
-				$2,
-				$3,
-				$4,
-				$5,
-				$6
-			FROM uploads u
-			WHERE u.upload_id = $1
-		`
-
-		_, err := tx.Exec(ctx, query, id, partNumber, offset, slabKey, dataOffset, dataLength)
-		if err != nil {
-			return fmt.Errorf("couldn't insert part: %v", err)
-		}
-		return nil
-	})
-}
-
-// FinalizeUpload creates a new object entry for the completed upload, copies
-// all associated parts as metadata entries, and deletes the upload entry.
-func (db *Database) FinalizeUpload(uploadID string) error {
+// AddBufferedSlab adds a new buffered slab entry and associates it with
+// the given upload ID and offset.
+func (db *Database) AddBufferedSlab(uploadID string, offset uint64, data []byte) error {
 	id, err := hex.DecodeString(uploadID)
 	if err != nil {
 		return err
@@ -226,125 +250,459 @@ func (db *Database) FinalizeUpload(uploadID string) error {
 	return db.txn(func(ctx context.Context, tx pgx.Tx) error {
 		const query = `
 			WITH target_upload AS (
-				SELECT
-					u.id,
-					u.share_name,
-					u.directory_id,
-					u.name,
-					u.full_path,
-					u.account
+				SELECT u.id, u.object_id, o.share_name
 				FROM uploads u
+				JOIN objects o ON o.id = u.object_id
 				WHERE u.upload_id = $1
 			),
-			new_object AS (
-				INSERT INTO objects (
-					share_name,
-					directory_id,
-					name,
-					full_path,
-					size,
-					account
-				)
-				SELECT
-					u.share_name,
-					u.directory_id,
-					u.name,
-					u.full_path,
-					COALESCE(SUM(p.data_length), 0),
-					u.account
-				FROM target_upload u
-				LEFT JOIN parts p ON p.upload_id = u.id
-				GROUP BY
-					u.id,
-					u.share_name,
-					u.directory_id,
-					u.name,
-					u.full_path,
-					u.account
+			new_buffer AS (
+				INSERT INTO buffers (share_name, data)
+				SELECT tu.share_name, $2
+				FROM target_upload tu
 				RETURNING id
 			),
-			copied_metadata AS (
+			new_metadata AS (
 				INSERT INTO metadata (
 					object_id,
 					obj_offset,
-					slab_key,
+					upload_id,
 					buffer_id,
 					data_offset,
 					data_length
 				)
 				SELECT
-					o.id,
-					p.obj_offset,
-					p.slab_key,
-					p.buffer_id,
-					p.data_offset,
-					p.data_length
-				FROM parts p
-				JOIN target_upload u ON u.id = p.upload_id
-				CROSS JOIN new_object o
-				ORDER BY p.obj_offset
+					tu.object_id,
+					$3,
+					tu.id,
+					nb.id,
+					0,
+					octet_length($2)
+				FROM target_upload tu
+				CROSS JOIN new_buffer nb
 				RETURNING id
-			),
-			deleted_upload AS (
-				DELETE FROM uploads u
-				USING target_upload t
-				WHERE u.id = t.id
-				RETURNING u.id
 			)
-			SELECT id
-			FROM new_object
-
+			INSERT INTO upload_jobs (upload_id, metadata_id)
+			SELECT tu.id, nm.id
+			FROM target_upload tu
+			CROSS JOIN new_metadata nm
 		`
 
-		var objectID uint64
-		err := tx.QueryRow(ctx, query, id).Scan(&objectID)
+		tag, err := tx.Exec(ctx, query, id, data, offset)
 		if err != nil {
+			return fmt.Errorf("failed to add buffered slab: %w", err)
+		}
+		if tag.RowsAffected() == 0 {
+			return ErrNotFound
+		}
+		return nil
+	})
+}
+
+// ClaimUploadJob retrieves and locks the next pending upload job for processing.
+func (db *Database) ClaimUploadJob(minSize uint64) (job UploadJob, err error) {
+	err = db.txn(func(ctx context.Context, tx pgx.Tx) error {
+		const cleanupQuery = `
+			DELETE FROM upload_jobs uj
+			WHERE NOT EXISTS (
+				SELECT 1
+				FROM metadata m
+				JOIN buffers b ON b.id = m.buffer_id
+				WHERE m.id = uj.metadata_id
+			)
+		`
+
+		if _, err := tx.Exec(ctx, cleanupQuery); err != nil {
+			return fmt.Errorf("failed to clean up stale upload jobs: %w", err)
+		}
+
+		const query = `
+			WITH picked AS (
+				SELECT
+					uj.id,
+					uj.upload_id,
+					uj.metadata_id
+				FROM upload_jobs uj
+				JOIN metadata m ON m.id = uj.metadata_id
+				JOIN buffers b ON b.id = m.buffer_id
+				WHERE m.data_length >= $1
+				ORDER BY uj.created_at
+				FOR UPDATE SKIP LOCKED
+				LIMIT 1
+			),
+			deleted AS (
+				DELETE FROM upload_jobs uj
+				USING picked p
+				WHERE uj.id = p.id
+				RETURNING uj.id, uj.upload_id, uj.metadata_id
+			)
+			SELECT
+				d.id,
+				d.upload_id,
+				m.id,
+				m.object_id,
+				m.buffer_id,
+				m.obj_offset,
+				m.data_offset,
+				m.data_length,
+				b.data
+			FROM deleted d
+			JOIN metadata m ON m.id = d.metadata_id
+			JOIN buffers b ON b.id = m.buffer_id
+		`
+
+		var data []byte
+		err := tx.QueryRow(ctx, query, minSize).Scan(
+			&job.ID,
+			&job.UploadID,
+			&job.MetadataID,
+			&job.ObjectID,
+			&job.BufferID,
+			&job.ObjOffset,
+			&job.DataOffset,
+			&job.DataLength,
+			&data,
+		)
+		if err != nil {
+			if errors.Is(err, pgx.ErrNoRows) {
+				return ErrNoUploadJobs
+			}
+			return fmt.Errorf("failed to claim upload job: %w", err)
+		}
+
+		end := job.DataOffset + job.DataLength
+		if end > uint64(len(data)) {
+			return fmt.Errorf("buffer slice out of bounds: offset %d, length %d, buffer size %d", job.DataOffset, job.DataLength, len(data))
+		}
+		job.Data = append([]byte(nil), data[job.DataOffset:end]...)
+		return nil
+	})
+	return
+}
+
+// CompleteUploadJob marks the given upload job as completed by associating the provided slab key
+// with the corresponding metadata entry and removing the buffer if it is no longer referenced.
+func (db *Database) CompleteUploadJob(metadataID uint64, bufferID uint64, slabKey types.Hash256) error {
+	return db.txn(func(ctx context.Context, tx pgx.Tx) error {
+		var uid *uint64
+		const lookupQuery = `
+			SELECT upload_id
+			FROM metadata
+			WHERE id = $1
+		`
+
+		if err := tx.QueryRow(ctx, lookupQuery, metadataID).Scan(&uid); err != nil {
 			if errors.Is(err, pgx.ErrNoRows) {
 				return ErrNotFound
 			}
+			return fmt.Errorf("failed to look up metadata before completion: %w", err)
+		}
 
-			return fmt.Errorf("couldn't finalize upload: %v", err)
+		const updateQuery = `
+			UPDATE metadata
+			SET
+				slab_key = $3,
+				buffer_id = NULL,
+				upload_id = NULL
+			WHERE id = $1
+				AND buffer_id = $2
+		`
+
+		tag, err := tx.Exec(ctx, updateQuery, metadataID, bufferID, slabKey[:])
+		if err != nil {
+			return fmt.Errorf("failed to update metadata: %w", err)
+		}
+		if tag.RowsAffected() == 0 {
+			var (
+				currentBid  *uint64
+				currentSlab []byte
+			)
+
+			const checkQuery = `
+				SELECT buffer_id, slab_key
+				FROM metadata
+				WHERE id = $1
+			`
+
+			err := tx.QueryRow(ctx, checkQuery, metadataID).Scan(&currentBid, &currentSlab)
+			if err != nil {
+				if errors.Is(err, pgx.ErrNoRows) {
+					return ErrNotFound
+				}
+				return fmt.Errorf("failed to verify metadata state: %w", err)
+			}
+
+			if currentBid == nil && len(currentSlab) == len(slabKey) {
+				var existing types.Hash256
+				copy(existing[:], currentSlab)
+				if existing == slabKey {
+					return nil
+				}
+				return fmt.Errorf("metadata %d already completed with different slab key", metadataID)
+			}
+
+			return ErrNotFound
+		}
+
+		const deleteQuery = `
+			DELETE FROM buffers b
+			WHERE b.id = $1
+				AND NOT EXISTS (
+					SELECT 1
+					FROM metadata m
+					WHERE m.buffer_id = b.id
+				)
+		`
+
+		if _, err := tx.Exec(ctx, deleteQuery, bufferID); err != nil {
+			return fmt.Errorf("failed to delete orphaned buffer: %w", err)
+		}
+
+		if uid != nil {
+			var done bool
+			const doneQuery = `
+				SELECT NOT EXISTS (
+					SELECT 1
+					FROM metadata
+					WHERE upload_id = $1
+				)
+				AND NOT EXISTS (
+					SELECT 1
+					FROM upload_jobs
+					WHERE upload_id = $1
+				)
+			`
+
+			if err := tx.QueryRow(ctx, doneQuery, *uid).Scan(&done); err != nil {
+				return fmt.Errorf("failed to check whether upload is complete: %w", err)
+			}
+
+			if done {
+				const deleteUploadQuery = `
+					DELETE FROM uploads
+					WHERE id = $1
+				`
+
+				if _, err := tx.Exec(ctx, deleteUploadQuery, *uid); err != nil {
+					return fmt.Errorf("failed to delete complete upload: %w", err)
+				}
+			}
 		}
 
 		return nil
 	})
 }
 
-// ListUploadParts retrieves the slab keys of all parts associated with the given upload ID.
-func (db *Database) ListUploadParts(uploadID string) (parts []types.Hash256, err error) {
-	id, err := hex.DecodeString(uploadID)
-	if err != nil {
-		return nil, err
-	}
-
-	err = db.txn(func(ctx context.Context, tx pgx.Tx) error {
+// RequeueUploadJob re-adds the given upload job to the queue for retrying.
+func (db *Database) RequeueUploadJob(uploadID, metadataID uint64) error {
+	return db.txn(func(ctx context.Context, tx pgx.Tx) error {
 		const query = `
-			SELECT p.slab_key
-			FROM parts p
-			JOIN uploads u ON u.id = p.upload_id
-			WHERE u.upload_id = $1 AND p.slab_key IS NOT NULL
-			ORDER BY p.obj_offset
+			INSERT INTO upload_jobs (upload_id, metadata_id)
+			VALUES ($1, $2)
+			ON CONFLICT (metadata_id) DO NOTHING
 		`
 
-		rows, err := tx.Query(ctx, query, id)
+		_, err := tx.Exec(ctx, query, uploadID, metadataID)
 		if err != nil {
-			return fmt.Errorf("couldn't list upload parts: %v", err)
+			return fmt.Errorf("failed to requeue upload job: %w", err)
 		}
-		defer rows.Close()
-
-		for rows.Next() {
-			var slabKey []byte
-			if err := rows.Scan(&slabKey); err != nil {
-				return fmt.Errorf("couldn't parse slab key: %v", err)
-			}
-			var hash types.Hash256
-			copy(hash[:], slabKey)
-			parts = append(parts, hash)
-		}
-		return rows.Err()
+		return nil
 	})
+}
 
-	return parts, err
+// FinalizeUpload finalizes the upload by making the associated object visible.
+func (db *Database) FinalizeUpload(uploadID string) error {
+	id, err := hex.DecodeString(uploadID)
+	if err != nil {
+		return err
+	}
+
+	return db.txn(func(ctx context.Context, tx pgx.Tx) error {
+		var uid, soid uint64
+		var share, path string
+		var aid uint64
+		const lookup = `
+			SELECT u.id, u.object_id, o.share_name, o.full_path, o.account
+			FROM uploads u
+			JOIN objects o ON o.id = u.object_id
+			WHERE u.upload_id = $1
+				AND o.temporary = TRUE
+		`
+
+		if err := tx.QueryRow(ctx, lookup, id).Scan(&uid, &soid, &share, &path, &aid); err != nil {
+			if errors.Is(err, pgx.ErrNoRows) {
+				return ErrNotFound
+			}
+			return fmt.Errorf("failed to lookup upload: %w", err)
+		}
+
+		var ok bool
+		const validate = `
+			SELECT NOT EXISTS (
+				SELECT 1
+				FROM metadata
+				WHERE object_id = $1
+					AND (
+						(slab_key IS NULL AND buffer_id IS NULL)
+						OR
+						(slab_key IS NOT NULL AND buffer_id IS NOT NULL)
+					)
+			)
+		`
+
+		if err := tx.QueryRow(ctx, validate, soid).Scan(&ok); err != nil {
+			return fmt.Errorf("failed to validate metadata state: %w", err)
+		}
+		if !ok {
+			return errors.New("cannot finalize upload: invalid metadata state")
+		}
+
+		var oid uint64
+		const findVisible = `
+			SELECT id
+			FROM objects
+			WHERE share_name = $1
+				AND full_path = $2
+				AND temporary = FALSE
+		`
+
+		err = tx.QueryRow(ctx, findVisible, share, path).Scan(&oid)
+		if err != nil && !errors.Is(err, pgx.ErrNoRows) {
+			return fmt.Errorf("failed to find visible object: %w", err)
+		}
+
+		finalOid := soid
+
+		if errors.Is(err, pgx.ErrNoRows) {
+			const makeVisible = `
+				UPDATE objects o
+				SET
+					temporary = FALSE,
+					modified_at = NOW(),
+					size = COALESCE((
+						SELECT SUM(data_length)
+						FROM metadata
+						WHERE object_id = o.id
+					), 0)
+				WHERE o.id = $1
+			`
+
+			tag, err := tx.Exec(ctx, makeVisible, soid)
+			if err != nil {
+				return fmt.Errorf("failed to make object visible: %w", err)
+			}
+			if tag.RowsAffected() == 0 {
+				return ErrNotFound
+			}
+		} else {
+			const collectBuffers = `
+				SELECT DISTINCT buffer_id
+				FROM metadata m
+				WHERE m.object_id = $1
+					AND m.buffer_id IS NOT NULL
+			`
+
+			rows, err := tx.Query(ctx, collectBuffers, oid)
+			if err != nil {
+				return fmt.Errorf("failed to collect buffers: %w", err)
+			}
+			var bids []uint64
+			for rows.Next() {
+				var bid uint64
+				if err := rows.Scan(&bid); err != nil {
+					rows.Close()
+					return fmt.Errorf("failed to scan buffer ID: %w", err)
+				}
+				bids = append(bids, bid)
+			}
+			if err := rows.Err(); err != nil {
+				rows.Close()
+				return fmt.Errorf("failed to iterate buffer IDs: %w", err)
+			}
+			rows.Close()
+
+			const deleteVisible = `
+				DELETE FROM metadata
+				WHERE object_id = $1
+			`
+
+			if _, err := tx.Exec(ctx, deleteVisible, oid); err != nil {
+				return fmt.Errorf("failed to delete old metadata: %w", err)
+			}
+
+			const moveMetadata = `
+				UPDATE metadata
+				SET object_id = $1
+				WHERE object_id = $2
+			`
+
+			if _, err := tx.Exec(ctx, moveMetadata, oid, soid); err != nil {
+				return fmt.Errorf("failed to move metadata: %w", err)
+			}
+
+			const updateVisible = `
+				UPDATE objects
+				SET
+					account = $2,
+					modified_at = NOW(),
+					size = COALESCE((
+						SELECT SUM(data_length)
+						FROM metadata
+						WHERE object_id = $1
+					), 0)
+				WHERE id = $1
+			`
+
+			tag, err := tx.Exec(ctx, updateVisible, oid, aid)
+			if err != nil {
+				return fmt.Errorf("failed to update visible object: %w", err)
+			}
+			if tag.RowsAffected() == 0 {
+				return ErrNotFound
+			}
+
+			const deleteTemporary = `
+				DELETE FROM objects
+				WHERE id = $1
+			`
+
+			tag, err = tx.Exec(ctx, deleteTemporary, soid)
+			if err != nil {
+				return fmt.Errorf("failed to delete temporary object: %w", err)
+			}
+			if tag.RowsAffected() == 0 {
+				return ErrNotFound
+			}
+
+			for _, bid := range bids {
+				if _, err := tx.Exec(ctx, `
+					DELETE FROM buffers b
+					WHERE b.id = $1
+						AND NOT EXISTS (
+							SELECT 1
+							FROM metadata m
+							WHERE m.buffer_id = b.id
+						)
+				`, bid); err != nil {
+					return fmt.Errorf("failed to delete orphaned buffer: %w", err)
+				}
+			}
+
+			finalOid = oid
+		}
+
+		const clearUploadID = `
+			UPDATE metadata
+			SET upload_id = NULL
+			WHERE object_id = $1
+				AND upload_id = $2
+		`
+
+		if _, err := tx.Exec(ctx, clearUploadID, finalOid, uid); err != nil {
+			return fmt.Errorf("failed to clear upload ID from metadata: %w", err)
+		}
+
+		return nil
+	})
 }
 
 // ListSlabs retrieves the slab keys of all files at or down the specified path.
@@ -368,6 +726,7 @@ func (db *Database) ListSlabs(acc Account, share, path string) (slabs []types.Ha
 				CROSS JOIN caller c
 				WHERE o.share_name = $1
 					AND o.full_path = $2
+					AND o.temporary = FALSE
 					AND (
 						o.account = c.id
 						OR (
@@ -405,6 +764,7 @@ func (db *Database) ListSlabs(acc Account, share, path string) (slabs []types.Ha
 				CROSS JOIN caller c
 				WHERE o.share_name = $1
 					AND o.full_path LIKE td.full_path || '/%%'
+					AND o.temporary = FALSE
 					AND (
 						o.account = c.id
 						OR (
@@ -458,7 +818,7 @@ func (db *Database) ListSlabs(acc Account, share, path string) (slabs []types.Ha
 }
 
 // GetMetadata retrieves the metadata of the file at the specified path.
-func (db *Database) GetMetadata(acc Account, share, path string) (slabs []SlabSlice, partial SlabSlice, err error) {
+func (db *Database) GetMetadata(acc Account, share, path string) (slabs []SlabSlice, err error) {
 	path = normalizePath(path)
 
 	err = db.txn(func(ctx context.Context, tx pgx.Tx) error {
@@ -478,6 +838,7 @@ func (db *Database) GetMetadata(acc Account, share, path string) (slabs []SlabSl
 				CROSS JOIN caller c
 				WHERE o.share_name = $1
 					AND o.full_path = $2
+					AND o.temporary = FALSE
 					AND (
 						o.account = c.id
 						OR (
@@ -521,12 +882,13 @@ func (db *Database) GetMetadata(acc Account, share, path string) (slabs []SlabSl
 			}
 
 			if slabKey == nil {
-				partial = SlabSlice{
+				pr := SlabSlice{
 					Offset: dataOffset,
 					Length: dataLength,
 					At:     objOffset,
 					Data:   chunk[dataOffset : dataOffset+dataLength],
 				}
+				slabs = append(slabs, pr)
 				continue
 			}
 


### PR DESCRIPTION
This PR refactors the upload code, so all file parts are first written to a local buffer, and then the background upload worker uploads the complete slabs. The download code can use both local data and the already uploaded slabs.

This greatly improves the upload speeds, slightly improves the download speeds, and adds more robustness to the SMB2 server behavior.