### PR TITLE
Auth per account

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,11 +90,11 @@ database:
   database: <DATABASE>     # the name of the PostgreSQL database from the previous section
   sslMode: disable         # the SSL mode of the PostgreSQL server
 indexd:
-  appName: Sombrero                       # the name of the app, unique to the `indexd` node being connected to
-  description: Sombrero SMB server        # description of the app
-  logoURL: https://example.com/logo.png   # URL of the app logo, can be left as it is
-  serviceURL: https://example.com/service # URL of the app itself, can be left as it is (Sombrero has no service page)
-  seedPhrase: ''                          # if omitted, the server will generate a new seed phrase and put it here
+  appName: Sombrero                                                              # the name of the app, unique to the `indexd` node being connected to
+  description: Sombrero SMB server                                               # description of the app
+  logoURL: https://raw.githubusercontent.com/mike76-dev/sombrero/master/logo.png # URL of the app logo, can be left as it is
+  serviceURL: https://github.com/mike76-dev/sombrero                             # URL of the app itself, can be left as it is (Sombrero has no service page)
+  seedPhrase: ''                                                                 # if omitted, the server will generate a new seed phrase and put it here
 ```
 The server can be started either as a standalone executable or as a service (the latter is preferred). For example, on Linux:
 ```Bash
@@ -103,22 +103,65 @@ sudo sombrero --dir=<PATH_TO_SOMBRERO.YML>
 The superuser access is required because of the port 445 that the server is listening on.
 
 Now, you need to register shares and add user accounts that will be accessing these shares.
+The typical workflow is:
 
-To register a share, run (for example):
+### 1. Create a workgroup
+A workgroup can contain an arbitrary number of user accounts. Each workgroup can connect to a remote share and have its own storage quota on that share.
 ```Bash
-curl -u "":<API_PASSWORD> -X POST "http://127.0.0.1:9999/share" -d '{"name":"shared","type":"renterd","serverName":"http://127.0.0.1:9980","password":"1234","bucket":"default","remark":"renterd"}'
+curl -u "":<API_PASSWORD> -X POST "http://127.0.0.1:9999/workgroup"
 ```
 or
 ```Bash
-curl -u "":<API_PASSWORD> -X POST "http://127.0.0.1:9999/share" -d '{"name":"shared","type":"indexd","serverName":"https://sia.storage","remark":"Sia Foundation indexer","dataShards":10,"parityShards":20}'
+curl -u "":<API_PASSWORD> -X POST "http://127.0.0.1:9999/workgroup" -d '{"name":"home"}'
 ```
-To register a new account, run (for example):
+The difference between the two calls is that the second call allows creating a named workgroup.
+This is only useful when you a running a private server and know for sure that no other workgroup with the same name will ever be created.
+
+Example of the output:
+```Bash
+{"uuid":"8303eeb8-f30e-4607-9eb7-875df2c5bd52"}
+```
+### 2. Add user account(s) to the workgroup
+```Bash
+curl -u "":<API_PASSWORD> -X POST "http://127.0.0.1:9999/account" -d '{"username":"test","password":"123","workgroup":"8303eeb8-f30e-4607-9eb7-875df2c5bd52"}'
+```
+or
 ```Bash
 curl -u "":<API_PASSWORD> -X POST "http://127.0.0.1:9999/account" -d '{"username":"test","password":"123","workgroup":"home"}'
 ```
-To grant the account access to the share, run:
+### 3. Register a share
 ```Bash
-curl -u "":<API_PASSWORD> -X PUT "http://127.0.0.1:9999/share/shared/policy?username=test&workgroup=home&read=true&write=true&delete=true&execute=true"
+curl -u "":<API_PASSWORD> -X POST "http://127.0.0.1:9999/share" -d '{"name":"shared-renterd","type":"renterd","serverName":"http://127.0.0.1:9980","password":"1234","bucket":"default","remark":"renterd"}'
+```
+or
+```Bash
+curl -u "":<API_PASSWORD> -X POST "http://127.0.0.1:9999/share" -d '{"name":"shared-indexd","type":"indexd","serverName":"https://sia.storage","remark":"Sia Foundation indexer","dataShards":10,"parityShards":20}'
+```
+### 4. Connect the workgroup to the share
+In case of a `renterd` share, simply call
+```Bash
+curl -u "":<API_PASSWORD> -X PUT "http://127.0.0.1:9999/connect/home/shared-renterd"
+```
+Connecting to an `indexd` share is slightly more involved. First, request a connection:
+```Bash
+curl -u "":<API_PASSWORD> -X POST "http://127.0.0.1:9999/connect/8303eeb8-f30e-4607-9eb7-875df2c5bd52/shared-indexd"
+```
+Example of the output:
+```Bash
+{"url":"https://sia.storage/auth/connect/d10f2a960d7dfc947248f58758619b74"}
+```
+After visiting the URL provided and accepting the connection, run
+```Bash
+curl -u "":<API_PASSWORD> -X PUT "http://127.0.0.1:9999/connect/8303eeb8-f30e-4607-9eb7-875df2c5bd52/shared-indexd"
+```
+Example of the output:
+```Bash
+{"appKey":"03a2aab52b79f674354af35b0030cd0cd45b51f53a1a75795a58c85844767b3d3ac38242c05637cac5b8b7fbcea55d29826845fdfc0ef19894d7640438f43a22"}
+```
+### 5. Grant access to the share
+To grant an account access to the share, run:
+```Bash
+curl -u "":<API_PASSWORD> -X PUT "http://127.0.0.1:9999/share/shared-indexd/policy?username=test&workgroup=8303eeb8-f30e-4607-9eb7-875df2c5bd52&read=true&write=true&delete=true&execute=true"
 ```
 
 ## Security Considerations
@@ -200,7 +243,7 @@ export TEST_INIT_SQL=../init.sql
 ```
 3. Run the tests
 ```Bash
-go test ./client -v
+go test ./... -v
 ```
 
 ## Bug Reporting

--- a/api/api.go
+++ b/api/api.go
@@ -8,11 +8,14 @@ import (
 	"net/http"
 	"strconv"
 	"strings"
+	"sync"
+	"time"
 
 	"github.com/google/uuid"
 	"github.com/julienschmidt/httprouter"
 	"github.com/mike76-dev/sombrero/stores"
 	"go.sia.tech/core/types"
+	sdk "go.sia.tech/siastorage"
 )
 
 // Store implements the database store.
@@ -60,13 +63,26 @@ type WorkgroupResponse struct {
 	UUID uuid.UUID `json:"uuid"`
 }
 
+// ConnectRequestResponse is the response type for POST /connect/request/:workgroup/:share.
+type ConnectRequestResponse struct {
+	URL string `json:"url"`
+}
+
+// ConnectResponse is the response type for PUT /connect/:workgroup/:share when
+// completing a first-time registration. AppKey is the derived key the caller
+// should persist for future reconnections.
+type ConnectResponse struct {
+	AppKey string `json:"appKey"`
+}
+
 // API represents the API call handler.
 type API struct {
-	router httprouter.Router
-	store  Store
-	cfg    stores.IndexdConfig
-	ctx    context.Context
-	rl     *ratelimiter
+	router          httprouter.Router
+	store           Store
+	cfg             stores.IndexdConfig
+	ctx             context.Context
+	rl              *ratelimiter
+	pendingBuilders sync.Map // key: "workgroupUUID/shareName" → *sdk.Builder
 }
 
 // NewAPI returns an initialized API object.
@@ -185,6 +201,10 @@ func (api *API) buildHTTPRoutes() {
 
 	router.DELETE("/workgroup/:uuid", func(w http.ResponseWriter, req *http.Request, ps httprouter.Params) {
 		api.workgroupHandlerDELETE(w, req, ps)
+	})
+
+	router.POST("/connect/:workgroup/:share", func(w http.ResponseWriter, req *http.Request, ps httprouter.Params) {
+		api.connectHandlerPOST(w, req, ps)
 	})
 
 	router.PUT("/connect/:workgroup/:share", func(w http.ResponseWriter, req *http.Request, ps httprouter.Params) {
@@ -812,7 +832,80 @@ func (api *API) workgroupHandlerDELETE(w http.ResponseWriter, req *http.Request,
 	writeSuccess(w)
 }
 
+// connectHandlerPOST handles the POST /connect/:workgroup/:share calls.
+// It initiates an indexd connection-approval flow by sending a registration request
+// to the indexer and returning the URL the admin must visit to approve it.
+func (api *API) connectHandlerPOST(w http.ResponseWriter, req *http.Request, ps httprouter.Params) {
+	if api.rl.limitExceeded(getRemoteHost(req)) {
+		writeError(w, "too many requests", http.StatusTooManyRequests)
+		return
+	}
+
+	u, err := uuid.Parse(ps.ByName("workgroup"))
+	if err != nil {
+		writeError(w, "invalid workgroup UUID", http.StatusBadRequest)
+		return
+	}
+
+	wg, err := api.store.FindWorkgroup(u)
+	if err != nil {
+		log.Printf("failed to find workgroup: %v", err)
+		writeError(w, "internal error", http.StatusInternalServerError)
+		return
+	}
+	if wg.ID == 0 {
+		writeError(w, "workgroup not found", http.StatusNotFound)
+		return
+	}
+
+	share, err := api.store.GetShare(strings.ToLower(ps.ByName("share")))
+	if err != nil {
+		log.Printf("failed to find share: %v", err)
+		writeError(w, "internal error", http.StatusInternalServerError)
+		return
+	}
+	if share.Name == "" {
+		writeError(w, "share not found", http.StatusNotFound)
+		return
+	}
+	if share.Type != "indexd" {
+		writeError(w, "connection requests are only supported for indexd shares", http.StatusBadRequest)
+		return
+	}
+
+	builder := sdk.NewBuilder(share.ServerName, sdk.AppMetadata{
+		ID:          types.HashBytes(append([]byte(api.cfg.Name), []byte(api.cfg.Description)...)),
+		Name:        api.cfg.Name,
+		Description: api.cfg.Description,
+		LogoURL:     api.cfg.LogoURL,
+		ServiceURL:  api.cfg.ServiceURL,
+	})
+
+	approvalURL, err := builder.RequestConnection(req.Context())
+	if err != nil {
+		log.Printf("failed to request connection: %v", err)
+		writeError(w, "internal error", http.StatusInternalServerError)
+		return
+	}
+
+	pendingKey := u.String() + "/" + share.Name
+	api.pendingBuilders.Store(pendingKey, builder)
+	go func() {
+		select {
+		case <-time.After(10 * time.Minute):
+			api.pendingBuilders.Delete(pendingKey)
+		case <-api.ctx.Done():
+		}
+	}()
+	writeJSON(w, ConnectRequestResponse{URL: approvalURL})
+}
+
 // connectHandlerPUT handles the PUT /connect/:workgroup/:share calls.
+// Three paths:
+//  1. Body with appKey (hex) — reconnect using an existing key.
+//  2. No body, indexd share, pending builder present — complete the approval flow
+//     started by POST /connect/request, derive the app key, and return it.
+//  3. No body, renterd share — no key required.
 func (api *API) connectHandlerPUT(w http.ResponseWriter, req *http.Request, ps httprouter.Params) {
 	if api.rl.limitExceeded(getRemoteHost(req)) {
 		writeError(w, "too many requests", http.StatusTooManyRequests)
@@ -858,14 +951,50 @@ func (api *API) connectHandlerPUT(w http.ResponseWriter, req *http.Request, ps h
 	}
 
 	var appKey types.PrivateKey
+
 	if body.AppKey != "" {
+		// Path 1: reconnect with a known app key.
 		keyBytes, err := hex.DecodeString(body.AppKey)
 		if err != nil {
 			writeError(w, "invalid app key encoding", http.StatusBadRequest)
 			return
 		}
 		appKey = types.PrivateKey(keyBytes)
+		if len(appKey) != 64 {
+			writeError(w, "indexd share requires a valid 64-byte app key", http.StatusBadRequest)
+			return
+		}
+	} else if share.Type == "indexd" {
+		// Path 2: complete a pending first-time registration.
+		pendingKey := u.String() + "/" + share.Name
+		v, ok := api.pendingBuilders.Load(pendingKey)
+		if !ok {
+			writeError(w, "no pending connection request found; call POST /connect/request first", http.StatusBadRequest)
+			return
+		}
+		builder := v.(*sdk.Builder)
+
+		ctx, cancel := context.WithTimeout(req.Context(), 2*time.Minute)
+		defer cancel()
+
+		if err := builder.WaitForApproval(ctx); err != nil {
+			api.pendingBuilders.Delete(pendingKey)
+			log.Printf("connection approval failed: %v", err)
+			writeError(w, "connection not approved: "+err.Error(), http.StatusBadRequest)
+			return
+		}
+
+		sdkInst, err := builder.Register(req.Context(), api.cfg.SeedPhrase)
+		if err != nil {
+			api.pendingBuilders.Delete(pendingKey)
+			log.Printf("failed to register app: %v", err)
+			writeError(w, "internal error", http.StatusInternalServerError)
+			return
+		}
+		api.pendingBuilders.Delete(pendingKey)
+		appKey = sdkInst.AppKey()
 	}
+	// Path 3: renterd share — appKey stays nil, AddConnection handles it.
 
 	if err := api.store.AddConnection(wg, share, appKey); err != nil {
 		log.Printf("failed to add connection: %v", err)
@@ -873,7 +1002,11 @@ func (api *API) connectHandlerPUT(w http.ResponseWriter, req *http.Request, ps h
 		return
 	}
 
-	writeSuccess(w)
+	if len(appKey) > 0 {
+		writeJSON(w, ConnectResponse{AppKey: hex.EncodeToString(appKey)})
+	} else {
+		writeSuccess(w)
+	}
 }
 
 // connectHandlerDELETE handles the DELETE /connect/:workgroup/:share calls.

--- a/api/api.go
+++ b/api/api.go
@@ -55,6 +55,11 @@ type IsBannedResponse struct {
 	Reason string `json:"reason"`
 }
 
+// WorkgroupResponse is the response type for POST /workgroup request.
+type WorkgroupResponse struct {
+	UUID uuid.UUID `json:"uuid"`
+}
+
 // API represents the API call handler.
 type API struct {
 	router httprouter.Router
@@ -736,27 +741,15 @@ func (api *API) workgroupHandlerPOST(w http.ResponseWriter, req *http.Request, _
 		return
 	}
 
-	var body struct {
-		UUID string `json:"uuid"`
-	}
-	if err := json.NewDecoder(req.Body).Decode(&body); err != nil {
-		writeError(w, "invalid body", http.StatusBadRequest)
-		return
-	}
-
-	u, err := uuid.Parse(body.UUID)
-	if err != nil {
-		writeError(w, "invalid UUID", http.StatusBadRequest)
-		return
-	}
-
+	u := uuid.New()
 	if err := api.store.AddWorkgroup(stores.Workgroup{UUID: u}); err != nil {
 		log.Printf("failed to add workgroup: %v", err)
 		writeError(w, "internal error", http.StatusInternalServerError)
 		return
 	}
 
-	writeSuccess(w)
+	log.Printf("created new workgroup: %s", u)
+	writeJSON(w, WorkgroupResponse{UUID: u})
 }
 
 // workgroupHandlerGET handles the GET /workgroup/:uuid calls.

--- a/api/api.go
+++ b/api/api.go
@@ -2,17 +2,17 @@ package api
 
 import (
 	"context"
+	"encoding/hex"
 	"encoding/json"
-	"fmt"
 	"log"
 	"net/http"
 	"strconv"
 	"strings"
 
+	"github.com/google/uuid"
 	"github.com/julienschmidt/httprouter"
 	"github.com/mike76-dev/sombrero/stores"
 	"go.sia.tech/core/types"
-	sdk "go.sia.tech/siastorage"
 )
 
 // Store implements the database store.
@@ -30,6 +30,10 @@ type Store interface {
 	FindAccounts(workgroup string) (accs []stores.Account, err error)
 	RemoveAccounts(workgroup string) error
 
+	AddWorkgroup(wg stores.Workgroup) error
+	FindWorkgroup(u uuid.UUID) (stores.Workgroup, error)
+	RemoveWorkgroup(wg stores.Workgroup) error
+
 	GetAccessRights(share stores.Share, acc stores.Account) (ar stores.AccessRights, err error)
 	SetAccessRights(ar stores.AccessRights) error
 	RemoveAccessRights(share stores.Share, acc stores.Account) error
@@ -40,6 +44,9 @@ type Store interface {
 	GetShare(name string) (s stores.Share, err error)
 	GetShares(acc stores.Account) (shares []stores.Share, err error)
 	GetAccounts(sh stores.Share) (ars []stores.AccessRights, err error)
+
+	AddConnection(wg stores.Workgroup, share stores.Share, appKey types.PrivateKey) error
+	RemoveConnection(wg stores.Workgroup, share stores.Share) error
 }
 
 // IsBannedResponse is the response type for GET /banned request.
@@ -91,8 +98,8 @@ func (api *API) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 func (api *API) buildHTTPRoutes() {
 	router := httprouter.New()
 
-	router.GET("/banned/:host", func(w http.ResponseWriter, req *http.Request, ps httprouter.Params) {
-		api.bannedHandlerGET(w, req, ps)
+	router.GET("/ban/:host", func(w http.ResponseWriter, req *http.Request, ps httprouter.Params) {
+		api.banHandlerGET(w, req, ps)
 	})
 
 	router.PUT("/ban/:host", func(w http.ResponseWriter, req *http.Request, ps httprouter.Params) {
@@ -163,6 +170,26 @@ func (api *API) buildHTTPRoutes() {
 		api.accountPolicyHandlerDELETE(w, req, ps)
 	})
 
+	router.POST("/workgroup", func(w http.ResponseWriter, req *http.Request, ps httprouter.Params) {
+		api.workgroupHandlerPOST(w, req, ps)
+	})
+
+	router.GET("/workgroup/:uuid", func(w http.ResponseWriter, req *http.Request, ps httprouter.Params) {
+		api.workgroupHandlerGET(w, req, ps)
+	})
+
+	router.DELETE("/workgroup/:uuid", func(w http.ResponseWriter, req *http.Request, ps httprouter.Params) {
+		api.workgroupHandlerDELETE(w, req, ps)
+	})
+
+	router.PUT("/connect/:workgroup/:share", func(w http.ResponseWriter, req *http.Request, ps httprouter.Params) {
+		api.connectHandlerPUT(w, req, ps)
+	})
+
+	router.DELETE("/connect/:workgroup/:share", func(w http.ResponseWriter, req *http.Request, ps httprouter.Params) {
+		api.connectHandlerDELETE(w, req, ps)
+	})
+
 	api.router = *router
 }
 
@@ -190,8 +217,8 @@ func writeSuccess(w http.ResponseWriter) {
 	w.WriteHeader(http.StatusNoContent)
 }
 
-// bannedHandlerGET handles the GET /banned/:host calls.
-func (api *API) bannedHandlerGET(w http.ResponseWriter, req *http.Request, ps httprouter.Params) {
+// banHandlerGET handles the GET /ban/:host calls.
+func (api *API) banHandlerGET(w http.ResponseWriter, req *http.Request, ps httprouter.Params) {
 	if api.rl.limitExceeded(getRemoteHost(req)) {
 		writeError(w, "too many requests", http.StatusTooManyRequests)
 		return
@@ -403,38 +430,6 @@ func (api *API) shareHandlerPOST(w http.ResponseWriter, req *http.Request, _ htt
 		return
 	}
 
-	if share.Type == "indexd" {
-		builder := sdk.NewBuilder(share.ServerName, sdk.AppMetadata{
-			ID:          types.HashBytes(append([]byte(api.cfg.Name), []byte(api.cfg.Description)...)),
-			Name:        api.cfg.Name,
-			Description: api.cfg.Description,
-			LogoURL:     api.cfg.LogoURL,
-			ServiceURL:  api.cfg.ServiceURL,
-		})
-		respURL, err := builder.RequestConnection(api.ctx)
-		if err != nil {
-			log.Printf("failed to request app connection: %v", err)
-			writeError(w, "internal error", http.StatusInternalServerError)
-			return
-		}
-		fmt.Println("Please approve the app connection by visiting the following URL:", respURL)
-		err = builder.WaitForApproval(api.ctx)
-		if err != nil {
-			log.Printf("failed to wait for app approval: %v", err)
-			writeError(w, "internal error", http.StatusInternalServerError)
-			return
-		}
-		client, err := builder.Register(api.ctx, api.cfg.SeedPhrase)
-		if err != nil {
-			log.Printf("failed to register app: %v", err)
-			writeError(w, "internal error", http.StatusInternalServerError)
-			return
-		}
-		share.AppKey = make(types.PrivateKey, 64)
-		copy(share.AppKey, client.AppKey()[:])
-		log.Print("app registered successfully")
-	}
-
 	if err := api.store.RegisterShare(share); err != nil {
 		log.Printf("failed to register share: %v", err)
 		writeError(w, "internal error", http.StatusInternalServerError)
@@ -444,7 +439,7 @@ func (api *API) shareHandlerPOST(w http.ResponseWriter, req *http.Request, _ htt
 	writeSuccess(w)
 }
 
-// shareHandlerGET handles the GET /share/:idorname calls.
+// shareHandlerGET handles the GET /share/:name calls.
 func (api *API) shareHandlerGET(w http.ResponseWriter, req *http.Request, ps httprouter.Params) {
 	if api.rl.limitExceeded(getRemoteHost(req)) {
 		writeError(w, "too many requests", http.StatusTooManyRequests)
@@ -468,7 +463,7 @@ func (api *API) shareHandlerGET(w http.ResponseWriter, req *http.Request, ps htt
 	writeJSON(w, share)
 }
 
-// shareHandlerDELETE handles the DELETE /share/:idorname calls.
+// shareHandlerDELETE handles the DELETE /share/:name calls.
 func (api *API) shareHandlerDELETE(w http.ResponseWriter, req *http.Request, ps httprouter.Params) {
 	if api.rl.limitExceeded(getRemoteHost(req)) {
 		writeError(w, "too many requests", http.StatusTooManyRequests)
@@ -490,7 +485,7 @@ func (api *API) shareHandlerDELETE(w http.ResponseWriter, req *http.Request, ps 
 	writeSuccess(w)
 }
 
-// shareAccountsHandlerGET handles the GET /share/:idorname/accounts calls.
+// shareAccountsHandlerGET handles the GET /share/:name/accounts calls.
 func (api *API) shareAccountsHandlerGET(w http.ResponseWriter, req *http.Request, ps httprouter.Params) {
 	if api.rl.limitExceeded(getRemoteHost(req)) {
 		writeError(w, "too many requests", http.StatusTooManyRequests)
@@ -520,7 +515,7 @@ func (api *API) shareAccountsHandlerGET(w http.ResponseWriter, req *http.Request
 	writeJSON(w, ars)
 }
 
-// policyHandlerGET handles the GET /share/:idorname/policy calls.
+// policyHandlerGET handles the GET /share/:name/policy calls.
 func (api *API) policyHandlerGET(w http.ResponseWriter, req *http.Request, ps httprouter.Params) {
 	if api.rl.limitExceeded(getRemoteHost(req)) {
 		writeError(w, "too many requests", http.StatusTooManyRequests)
@@ -564,7 +559,7 @@ func (api *API) policyHandlerGET(w http.ResponseWriter, req *http.Request, ps ht
 	writeJSON(w, ar)
 }
 
-// policyHandlerPUT handles the PUT /share/:idorname/policy calls.
+// policyHandlerPUT handles the PUT /share/:name/policy calls.
 func (api *API) policyHandlerPUT(w http.ResponseWriter, req *http.Request, ps httprouter.Params) {
 	if api.rl.limitExceeded(getRemoteHost(req)) {
 		writeError(w, "too many requests", http.StatusTooManyRequests)
@@ -626,7 +621,7 @@ func (api *API) policyHandlerPUT(w http.ResponseWriter, req *http.Request, ps ht
 	writeSuccess(w)
 }
 
-// policyHandlerDELETE handles the DELETE /share/:idorname/policy calls.
+// policyHandlerDELETE handles the DELETE /share/:name/policy calls.
 func (api *API) policyHandlerDELETE(w http.ResponseWriter, req *http.Request, ps httprouter.Params) {
 	if api.rl.limitExceeded(getRemoteHost(req)) {
 		writeError(w, "too many requests", http.StatusTooManyRequests)
@@ -727,6 +722,204 @@ func (api *API) accountPolicyHandlerDELETE(w http.ResponseWriter, req *http.Requ
 
 	if err := api.store.ClearAccessRights(acc); err != nil {
 		log.Printf("failed to clear policies: %v", err)
+		writeError(w, "internal error", http.StatusInternalServerError)
+		return
+	}
+
+	writeSuccess(w)
+}
+
+// workgroupHandlerPOST handles the POST /workgroup calls.
+func (api *API) workgroupHandlerPOST(w http.ResponseWriter, req *http.Request, _ httprouter.Params) {
+	if api.rl.limitExceeded(getRemoteHost(req)) {
+		writeError(w, "too many requests", http.StatusTooManyRequests)
+		return
+	}
+
+	var body struct {
+		UUID string `json:"uuid"`
+	}
+	if err := json.NewDecoder(req.Body).Decode(&body); err != nil {
+		writeError(w, "invalid body", http.StatusBadRequest)
+		return
+	}
+
+	u, err := uuid.Parse(body.UUID)
+	if err != nil {
+		writeError(w, "invalid UUID", http.StatusBadRequest)
+		return
+	}
+
+	if err := api.store.AddWorkgroup(stores.Workgroup{UUID: u}); err != nil {
+		log.Printf("failed to add workgroup: %v", err)
+		writeError(w, "internal error", http.StatusInternalServerError)
+		return
+	}
+
+	writeSuccess(w)
+}
+
+// workgroupHandlerGET handles the GET /workgroup/:uuid calls.
+func (api *API) workgroupHandlerGET(w http.ResponseWriter, req *http.Request, ps httprouter.Params) {
+	if api.rl.limitExceeded(getRemoteHost(req)) {
+		writeError(w, "too many requests", http.StatusTooManyRequests)
+		return
+	}
+
+	u, err := uuid.Parse(ps.ByName("uuid"))
+	if err != nil {
+		writeError(w, "invalid UUID", http.StatusBadRequest)
+		return
+	}
+
+	wg, err := api.store.FindWorkgroup(u)
+	if err != nil {
+		log.Printf("failed to find workgroup: %v", err)
+		writeError(w, "internal error", http.StatusInternalServerError)
+		return
+	}
+	if wg.ID == 0 {
+		writeError(w, "workgroup not found", http.StatusNotFound)
+		return
+	}
+
+	writeJSON(w, wg)
+}
+
+// workgroupHandlerDELETE handles the DELETE /workgroup/:uuid calls.
+func (api *API) workgroupHandlerDELETE(w http.ResponseWriter, req *http.Request, ps httprouter.Params) {
+	if api.rl.limitExceeded(getRemoteHost(req)) {
+		writeError(w, "too many requests", http.StatusTooManyRequests)
+		return
+	}
+
+	u, err := uuid.Parse(ps.ByName("uuid"))
+	if err != nil {
+		writeError(w, "invalid UUID", http.StatusBadRequest)
+		return
+	}
+
+	wg, err := api.store.FindWorkgroup(u)
+	if err != nil {
+		log.Printf("failed to find workgroup: %v", err)
+		writeError(w, "internal error", http.StatusInternalServerError)
+		return
+	}
+	if wg.ID == 0 {
+		writeError(w, "workgroup not found", http.StatusNotFound)
+		return
+	}
+
+	if err := api.store.RemoveWorkgroup(wg); err != nil {
+		log.Printf("failed to remove workgroup: %v", err)
+		writeError(w, "internal error", http.StatusInternalServerError)
+		return
+	}
+
+	writeSuccess(w)
+}
+
+// connectHandlerPUT handles the PUT /connect/:workgroup/:share calls.
+func (api *API) connectHandlerPUT(w http.ResponseWriter, req *http.Request, ps httprouter.Params) {
+	if api.rl.limitExceeded(getRemoteHost(req)) {
+		writeError(w, "too many requests", http.StatusTooManyRequests)
+		return
+	}
+
+	u, err := uuid.Parse(ps.ByName("workgroup"))
+	if err != nil {
+		writeError(w, "invalid workgroup UUID", http.StatusBadRequest)
+		return
+	}
+
+	wg, err := api.store.FindWorkgroup(u)
+	if err != nil {
+		log.Printf("failed to find workgroup: %v", err)
+		writeError(w, "internal error", http.StatusInternalServerError)
+		return
+	}
+	if wg.ID == 0 {
+		writeError(w, "workgroup not found", http.StatusNotFound)
+		return
+	}
+
+	share, err := api.store.GetShare(strings.ToLower(ps.ByName("share")))
+	if err != nil {
+		log.Printf("failed to find share: %v", err)
+		writeError(w, "internal error", http.StatusInternalServerError)
+		return
+	}
+	if share.Name == "" {
+		writeError(w, "share not found", http.StatusNotFound)
+		return
+	}
+
+	var body struct {
+		AppKey string `json:"appKey,omitempty"` // hex-encoded
+	}
+	if req.ContentLength > 0 {
+		if err := json.NewDecoder(req.Body).Decode(&body); err != nil {
+			writeError(w, "invalid body", http.StatusBadRequest)
+			return
+		}
+	}
+
+	var appKey types.PrivateKey
+	if body.AppKey != "" {
+		keyBytes, err := hex.DecodeString(body.AppKey)
+		if err != nil {
+			writeError(w, "invalid app key encoding", http.StatusBadRequest)
+			return
+		}
+		appKey = types.PrivateKey(keyBytes)
+	}
+
+	if err := api.store.AddConnection(wg, share, appKey); err != nil {
+		log.Printf("failed to add connection: %v", err)
+		writeError(w, "internal error", http.StatusInternalServerError)
+		return
+	}
+
+	writeSuccess(w)
+}
+
+// connectHandlerDELETE handles the DELETE /connect/:workgroup/:share calls.
+func (api *API) connectHandlerDELETE(w http.ResponseWriter, req *http.Request, ps httprouter.Params) {
+	if api.rl.limitExceeded(getRemoteHost(req)) {
+		writeError(w, "too many requests", http.StatusTooManyRequests)
+		return
+	}
+
+	u, err := uuid.Parse(ps.ByName("workgroup"))
+	if err != nil {
+		writeError(w, "invalid workgroup UUID", http.StatusBadRequest)
+		return
+	}
+
+	wg, err := api.store.FindWorkgroup(u)
+	if err != nil {
+		log.Printf("failed to find workgroup: %v", err)
+		writeError(w, "internal error", http.StatusInternalServerError)
+		return
+	}
+	if wg.ID == 0 {
+		writeError(w, "workgroup not found", http.StatusNotFound)
+		return
+	}
+
+	share, err := api.store.GetShare(strings.ToLower(ps.ByName("share")))
+	if err != nil {
+		log.Printf("failed to find share: %v", err)
+		writeError(w, "internal error", http.StatusInternalServerError)
+		return
+	}
+	if share.Name == "" {
+		writeError(w, "share not found", http.StatusNotFound)
+		return
+	}
+
+	if err := api.store.RemoveConnection(wg, share); err != nil {
+		log.Printf("failed to remove connection: %v", err)
 		writeError(w, "internal error", http.StatusInternalServerError)
 		return
 	}

--- a/api/api.go
+++ b/api/api.go
@@ -328,12 +328,15 @@ func (api *API) accountHandlerGET(w http.ResponseWriter, req *http.Request, _ ht
 	idValue := req.FormValue("id")
 	if idValue == "" {
 		username := strings.ToLower(req.FormValue("username"))
-		workgroup := strings.ToLower(req.FormValue("workgroup"))
 		if username == "" {
 			writeError(w, "username cannot be empty", http.StatusBadRequest)
 			return
 		}
-		acc, err = api.store.FindAccount(username, workgroup)
+		wg, ok := api.resolveWorkgroup(w, req.FormValue("workgroup"))
+		if !ok {
+			return
+		}
+		acc, err = api.store.FindAccount(username, wg.UUID.String())
 		if err != nil {
 			log.Printf("failed to find account: %v", err)
 			writeError(w, "internal error", http.StatusInternalServerError)
@@ -369,7 +372,12 @@ func (api *API) accountHandlerPOST(w http.ResponseWriter, req *http.Request, _ h
 		return
 	}
 	acc.Username = strings.ToLower(acc.Username)
-	acc.Workgroup = strings.ToLower(acc.Workgroup)
+
+	wg, ok := api.resolveWorkgroup(w, acc.Workgroup)
+	if !ok {
+		return
+	}
+	acc.Workgroup = wg.UUID.String()
 
 	if err := api.store.AddAccount(acc); err != nil {
 		log.Printf("failed to add account: %v", err)
@@ -388,13 +396,17 @@ func (api *API) accountHandlerDELETE(w http.ResponseWriter, req *http.Request, _
 	}
 
 	username := strings.ToLower(req.FormValue("username"))
-	workgroup := strings.ToLower(req.FormValue("workgroup"))
 	if username == "" {
 		writeError(w, "username cannot be empty", http.StatusBadRequest)
 		return
 	}
 
-	if err := api.store.RemoveAccount(username, workgroup); err != nil {
+	wg, ok := api.resolveWorkgroup(w, req.FormValue("workgroup"))
+	if !ok {
+		return
+	}
+
+	if err := api.store.RemoveAccount(username, wg.UUID.String()); err != nil {
 		log.Printf("failed to remove account: %v", err)
 		writeError(w, "internal error", http.StatusInternalServerError)
 		return
@@ -410,8 +422,12 @@ func (api *API) accountsHandlerGET(w http.ResponseWriter, req *http.Request, _ h
 		return
 	}
 
-	workgroup := strings.ToLower(req.FormValue("workgroup"))
-	accs, err := api.store.FindAccounts(workgroup)
+	wg, ok := api.resolveWorkgroup(w, req.FormValue("workgroup"))
+	if !ok {
+		return
+	}
+
+	accs, err := api.store.FindAccounts(wg.UUID.String())
 	if err != nil {
 		log.Printf("failed to find accounts: %v", err)
 		writeError(w, "internal error", http.StatusInternalServerError)
@@ -428,8 +444,12 @@ func (api *API) accountsHandlerDELETE(w http.ResponseWriter, req *http.Request, 
 		return
 	}
 
-	workgroup := strings.ToLower(req.FormValue("workgroup"))
-	if err := api.store.RemoveAccounts(workgroup); err != nil {
+	wg, ok := api.resolveWorkgroup(w, req.FormValue("workgroup"))
+	if !ok {
+		return
+	}
+
+	if err := api.store.RemoveAccounts(wg.UUID.String()); err != nil {
 		log.Printf("failed to remove accounts: %v", err)
 		writeError(w, "internal error", http.StatusInternalServerError)
 		return
@@ -556,13 +576,17 @@ func (api *API) policyHandlerGET(w http.ResponseWriter, req *http.Request, ps ht
 	}
 
 	username := strings.ToLower(req.FormValue("username"))
-	workgroup := strings.ToLower(req.FormValue("workgroup"))
 	if username == "" {
 		writeError(w, "username cannot be empty", http.StatusBadRequest)
 		return
 	}
 
-	acc, err := api.store.FindAccount(username, workgroup)
+	wg, ok := api.resolveWorkgroup(w, req.FormValue("workgroup"))
+	if !ok {
+		return
+	}
+
+	acc, err := api.store.FindAccount(username, wg.UUID.String())
 	if err != nil {
 		log.Printf("failed to find account: %v", err)
 		writeError(w, "internal error", http.StatusInternalServerError)
@@ -610,9 +634,13 @@ func (api *API) policyHandlerPUT(w http.ResponseWriter, req *http.Request, ps ht
 	}
 
 	username := strings.ToLower(req.FormValue("username"))
-	workgroup := strings.ToLower(req.FormValue("workgroup"))
 	if username == "" {
 		writeError(w, "username cannot be empty", http.StatusBadRequest)
+		return
+	}
+
+	wg, ok := api.resolveWorkgroup(w, req.FormValue("workgroup"))
+	if !ok {
 		return
 	}
 
@@ -625,7 +653,7 @@ func (api *API) policyHandlerPUT(w http.ResponseWriter, req *http.Request, ps ht
 	ea := strings.ToLower(req.FormValue("execute"))
 	executeAccess := ea == "true"
 
-	acc, err := api.store.FindAccount(username, workgroup)
+	acc, err := api.store.FindAccount(username, wg.UUID.String())
 	if err != nil {
 		log.Printf("failed to find account: %v", err)
 		writeError(w, "internal error", http.StatusInternalServerError)
@@ -662,13 +690,17 @@ func (api *API) policyHandlerDELETE(w http.ResponseWriter, req *http.Request, ps
 	}
 
 	username := strings.ToLower(req.FormValue("username"))
-	workgroup := strings.ToLower(req.FormValue("workgroup"))
 	if username == "" {
 		writeError(w, "username cannot be empty", http.StatusBadRequest)
 		return
 	}
 
-	acc, err := api.store.FindAccount(username, workgroup)
+	wg, ok := api.resolveWorkgroup(w, req.FormValue("workgroup"))
+	if !ok {
+		return
+	}
+
+	acc, err := api.store.FindAccount(username, wg.UUID.String())
 	if err != nil {
 		log.Printf("failed to find account: %v", err)
 		writeError(w, "internal error", http.StatusInternalServerError)
@@ -699,13 +731,17 @@ func (api *API) accountSharesHandlerGET(w http.ResponseWriter, req *http.Request
 	}
 
 	username := strings.ToLower(req.FormValue("username"))
-	workgroup := strings.ToLower(req.FormValue("workgroup"))
 	if username == "" {
 		writeError(w, "username cannot be empty", http.StatusBadRequest)
 		return
 	}
 
-	acc, err := api.store.FindAccount(username, workgroup)
+	wg, ok := api.resolveWorkgroup(w, req.FormValue("workgroup"))
+	if !ok {
+		return
+	}
+
+	acc, err := api.store.FindAccount(username, wg.UUID.String())
 	if err != nil {
 		log.Printf("failed to find account: %v", err)
 		writeError(w, "internal error", http.StatusInternalServerError)
@@ -734,13 +770,17 @@ func (api *API) accountPolicyHandlerDELETE(w http.ResponseWriter, req *http.Requ
 	}
 
 	username := strings.ToLower(req.FormValue("username"))
-	workgroup := strings.ToLower(req.FormValue("workgroup"))
 	if username == "" {
 		writeError(w, "username cannot be empty", http.StatusBadRequest)
 		return
 	}
 
-	acc, err := api.store.FindAccount(username, workgroup)
+	wg, ok := api.resolveWorkgroup(w, req.FormValue("workgroup"))
+	if !ok {
+		return
+	}
+
+	acc, err := api.store.FindAccount(username, wg.UUID.String())
 	if err != nil {
 		log.Printf("failed to find account: %v", err)
 		writeError(w, "internal error", http.StatusInternalServerError)

--- a/api/api.go
+++ b/api/api.go
@@ -35,6 +35,7 @@ type Store interface {
 
 	AddWorkgroup(wg stores.Workgroup) error
 	FindWorkgroup(u uuid.UUID) (stores.Workgroup, error)
+	FindWorkgroupByName(name string) (stores.Workgroup, error)
 	RemoveWorkgroup(wg stores.Workgroup) error
 
 	GetAccessRights(share stores.Share, acc stores.Account) (ar stores.AccessRights, err error)
@@ -61,6 +62,7 @@ type IsBannedResponse struct {
 // WorkgroupResponse is the response type for POST /workgroup request.
 type WorkgroupResponse struct {
 	UUID uuid.UUID `json:"uuid"`
+	Name string    `json:"name,omitempty"`
 }
 
 // ConnectRequestResponse is the response type for POST /connect/request/:workgroup/:share.
@@ -195,11 +197,11 @@ func (api *API) buildHTTPRoutes() {
 		api.workgroupHandlerPOST(w, req, ps)
 	})
 
-	router.GET("/workgroup/:uuid", func(w http.ResponseWriter, req *http.Request, ps httprouter.Params) {
+	router.GET("/workgroup/:id", func(w http.ResponseWriter, req *http.Request, ps httprouter.Params) {
 		api.workgroupHandlerGET(w, req, ps)
 	})
 
-	router.DELETE("/workgroup/:uuid", func(w http.ResponseWriter, req *http.Request, ps httprouter.Params) {
+	router.DELETE("/workgroup/:id", func(w http.ResponseWriter, req *http.Request, ps httprouter.Params) {
 		api.workgroupHandlerDELETE(w, req, ps)
 	})
 
@@ -754,6 +756,36 @@ func (api *API) accountPolicyHandlerDELETE(w http.ResponseWriter, req *http.Requ
 	writeSuccess(w)
 }
 
+// resolveWorkgroup looks up a workgroup by UUID or name.
+// If param parses as a UUID it uses FindWorkgroup; otherwise FindWorkgroupByName.
+// On failure it writes the appropriate error response and returns false.
+func (api *API) resolveWorkgroup(w http.ResponseWriter, param string) (stores.Workgroup, bool) {
+	if u, err := uuid.Parse(param); err == nil {
+		wg, err := api.store.FindWorkgroup(u)
+		if err != nil {
+			log.Printf("failed to find workgroup: %v", err)
+			writeError(w, "internal error", http.StatusInternalServerError)
+			return stores.Workgroup{}, false
+		}
+		if wg.ID == 0 {
+			writeError(w, "workgroup not found", http.StatusNotFound)
+			return stores.Workgroup{}, false
+		}
+		return wg, true
+	}
+	wg, err := api.store.FindWorkgroupByName(param)
+	if err != nil {
+		log.Printf("failed to find workgroup: %v", err)
+		writeError(w, "internal error", http.StatusInternalServerError)
+		return stores.Workgroup{}, false
+	}
+	if wg.ID == 0 {
+		writeError(w, "workgroup not found", http.StatusNotFound)
+		return stores.Workgroup{}, false
+	}
+	return wg, true
+}
+
 // workgroupHandlerPOST handles the POST /workgroup calls.
 func (api *API) workgroupHandlerPOST(w http.ResponseWriter, req *http.Request, _ httprouter.Params) {
 	if api.rl.limitExceeded(getRemoteHost(req)) {
@@ -761,65 +793,54 @@ func (api *API) workgroupHandlerPOST(w http.ResponseWriter, req *http.Request, _
 		return
 	}
 
+	var body struct {
+		Name string `json:"name,omitempty"`
+	}
+	if req.ContentLength > 0 {
+		if err := json.NewDecoder(req.Body).Decode(&body); err != nil {
+			writeError(w, "invalid body", http.StatusBadRequest)
+			return
+		}
+	}
+
 	u := uuid.New()
-	if err := api.store.AddWorkgroup(stores.Workgroup{UUID: u}); err != nil {
+	wg := stores.Workgroup{UUID: u, Name: body.Name}
+	if err := api.store.AddWorkgroup(wg); err != nil {
 		log.Printf("failed to add workgroup: %v", err)
 		writeError(w, "internal error", http.StatusInternalServerError)
 		return
 	}
 
 	log.Printf("created new workgroup: %s", u)
-	writeJSON(w, WorkgroupResponse{UUID: u})
+	writeJSON(w, WorkgroupResponse{UUID: u, Name: body.Name})
 }
 
-// workgroupHandlerGET handles the GET /workgroup/:uuid calls.
+// workgroupHandlerGET handles the GET /workgroup/:id calls.
+// :id may be a UUID or a workgroup name.
 func (api *API) workgroupHandlerGET(w http.ResponseWriter, req *http.Request, ps httprouter.Params) {
 	if api.rl.limitExceeded(getRemoteHost(req)) {
 		writeError(w, "too many requests", http.StatusTooManyRequests)
 		return
 	}
 
-	u, err := uuid.Parse(ps.ByName("uuid"))
-	if err != nil {
-		writeError(w, "invalid UUID", http.StatusBadRequest)
-		return
-	}
-
-	wg, err := api.store.FindWorkgroup(u)
-	if err != nil {
-		log.Printf("failed to find workgroup: %v", err)
-		writeError(w, "internal error", http.StatusInternalServerError)
-		return
-	}
-	if wg.ID == 0 {
-		writeError(w, "workgroup not found", http.StatusNotFound)
+	wg, ok := api.resolveWorkgroup(w, ps.ByName("id"))
+	if !ok {
 		return
 	}
 
 	writeJSON(w, wg)
 }
 
-// workgroupHandlerDELETE handles the DELETE /workgroup/:uuid calls.
+// workgroupHandlerDELETE handles the DELETE /workgroup/:id calls.
+// :id may be a UUID or a workgroup name.
 func (api *API) workgroupHandlerDELETE(w http.ResponseWriter, req *http.Request, ps httprouter.Params) {
 	if api.rl.limitExceeded(getRemoteHost(req)) {
 		writeError(w, "too many requests", http.StatusTooManyRequests)
 		return
 	}
 
-	u, err := uuid.Parse(ps.ByName("uuid"))
-	if err != nil {
-		writeError(w, "invalid UUID", http.StatusBadRequest)
-		return
-	}
-
-	wg, err := api.store.FindWorkgroup(u)
-	if err != nil {
-		log.Printf("failed to find workgroup: %v", err)
-		writeError(w, "internal error", http.StatusInternalServerError)
-		return
-	}
-	if wg.ID == 0 {
-		writeError(w, "workgroup not found", http.StatusNotFound)
+	wg, ok := api.resolveWorkgroup(w, ps.ByName("id"))
+	if !ok {
 		return
 	}
 
@@ -835,26 +856,15 @@ func (api *API) workgroupHandlerDELETE(w http.ResponseWriter, req *http.Request,
 // connectHandlerPOST handles the POST /connect/:workgroup/:share calls.
 // It initiates an indexd connection-approval flow by sending a registration request
 // to the indexer and returning the URL the admin must visit to approve it.
+// :workgroup may be a UUID or a workgroup name.
 func (api *API) connectHandlerPOST(w http.ResponseWriter, req *http.Request, ps httprouter.Params) {
 	if api.rl.limitExceeded(getRemoteHost(req)) {
 		writeError(w, "too many requests", http.StatusTooManyRequests)
 		return
 	}
 
-	u, err := uuid.Parse(ps.ByName("workgroup"))
-	if err != nil {
-		writeError(w, "invalid workgroup UUID", http.StatusBadRequest)
-		return
-	}
-
-	wg, err := api.store.FindWorkgroup(u)
-	if err != nil {
-		log.Printf("failed to find workgroup: %v", err)
-		writeError(w, "internal error", http.StatusInternalServerError)
-		return
-	}
-	if wg.ID == 0 {
-		writeError(w, "workgroup not found", http.StatusNotFound)
+	wg, ok := api.resolveWorkgroup(w, ps.ByName("workgroup"))
+	if !ok {
 		return
 	}
 
@@ -888,7 +898,7 @@ func (api *API) connectHandlerPOST(w http.ResponseWriter, req *http.Request, ps 
 		return
 	}
 
-	pendingKey := u.String() + "/" + share.Name
+	pendingKey := wg.UUID.String() + "/" + share.Name
 	api.pendingBuilders.Store(pendingKey, builder)
 	go func() {
 		select {
@@ -906,26 +916,15 @@ func (api *API) connectHandlerPOST(w http.ResponseWriter, req *http.Request, ps 
 //  2. No body, indexd share, pending builder present — complete the approval flow
 //     started by POST /connect/request, derive the app key, and return it.
 //  3. No body, renterd share — no key required.
+// :workgroup may be a UUID or a workgroup name.
 func (api *API) connectHandlerPUT(w http.ResponseWriter, req *http.Request, ps httprouter.Params) {
 	if api.rl.limitExceeded(getRemoteHost(req)) {
 		writeError(w, "too many requests", http.StatusTooManyRequests)
 		return
 	}
 
-	u, err := uuid.Parse(ps.ByName("workgroup"))
-	if err != nil {
-		writeError(w, "invalid workgroup UUID", http.StatusBadRequest)
-		return
-	}
-
-	wg, err := api.store.FindWorkgroup(u)
-	if err != nil {
-		log.Printf("failed to find workgroup: %v", err)
-		writeError(w, "internal error", http.StatusInternalServerError)
-		return
-	}
-	if wg.ID == 0 {
-		writeError(w, "workgroup not found", http.StatusNotFound)
+	wg, ok := api.resolveWorkgroup(w, ps.ByName("workgroup"))
+	if !ok {
 		return
 	}
 
@@ -966,7 +965,7 @@ func (api *API) connectHandlerPUT(w http.ResponseWriter, req *http.Request, ps h
 		}
 	} else if share.Type == "indexd" {
 		// Path 2: complete a pending first-time registration.
-		pendingKey := u.String() + "/" + share.Name
+		pendingKey := wg.UUID.String() + "/" + share.Name
 		v, ok := api.pendingBuilders.Load(pendingKey)
 		if !ok {
 			writeError(w, "no pending connection request found; call POST /connect/request first", http.StatusBadRequest)
@@ -1010,26 +1009,15 @@ func (api *API) connectHandlerPUT(w http.ResponseWriter, req *http.Request, ps h
 }
 
 // connectHandlerDELETE handles the DELETE /connect/:workgroup/:share calls.
+// :workgroup may be a UUID or a workgroup name.
 func (api *API) connectHandlerDELETE(w http.ResponseWriter, req *http.Request, ps httprouter.Params) {
 	if api.rl.limitExceeded(getRemoteHost(req)) {
 		writeError(w, "too many requests", http.StatusTooManyRequests)
 		return
 	}
 
-	u, err := uuid.Parse(ps.ByName("workgroup"))
-	if err != nil {
-		writeError(w, "invalid workgroup UUID", http.StatusBadRequest)
-		return
-	}
-
-	wg, err := api.store.FindWorkgroup(u)
-	if err != nil {
-		log.Printf("failed to find workgroup: %v", err)
-		writeError(w, "internal error", http.StatusInternalServerError)
-		return
-	}
-	if wg.ID == 0 {
-		writeError(w, "workgroup not found", http.StatusNotFound)
+	wg, ok := api.resolveWorkgroup(w, ps.ByName("workgroup"))
+	if !ok {
 		return
 	}
 

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -368,7 +368,10 @@ func TestBans(t *testing.T) {
 
 func TestAccount(t *testing.T) {
 	t.Run("GET by username", func(t *testing.T) {
-		ms := &mockStore{findAccount: foundAccount("alice", testUUID.String())}
+		ms := &mockStore{
+			findWorkgroup: foundWorkgroup(),
+			findAccount:   foundAccount("alice", testUUID.String()),
+		}
 		w := doRequest(newTestAPI(ms), http.MethodGet, "/account?username=alice&workgroup="+testUUID.String(), nil)
 		checkStatus(t, w, http.StatusOK)
 		acc := decodeJSON[stores.Account](t, w)
@@ -402,8 +405,11 @@ func TestAccount(t *testing.T) {
 	})
 
 	t.Run("GET by username store error", func(t *testing.T) {
-		ms := &mockStore{findAccount: func(string, string) (stores.Account, error) { return stores.Account{}, errStore }}
-		w := doRequest(newTestAPI(ms), http.MethodGet, "/account?username=alice", nil)
+		ms := &mockStore{
+			findWorkgroup: foundWorkgroup(),
+			findAccount:   func(string, string) (stores.Account, error) { return stores.Account{}, errStore },
+		}
+		w := doRequest(newTestAPI(ms), http.MethodGet, "/account?username=alice&workgroup="+testUUID.String(), nil)
 		checkStatus(t, w, http.StatusInternalServerError)
 	})
 
@@ -415,7 +421,10 @@ func TestAccount(t *testing.T) {
 
 	t.Run("POST creates account", func(t *testing.T) {
 		var got stores.Account
-		ms := &mockStore{addAccount: func(a stores.Account) error { got = a; return nil }}
+		ms := &mockStore{
+			findWorkgroup: foundWorkgroup(),
+			addAccount:    func(a stores.Account) error { got = a; return nil },
+		}
 		w := doRequest(newTestAPI(ms), http.MethodPost, "/account", stores.Account{
 			Username:  "Alice",
 			Password:  "secret",
@@ -436,14 +445,20 @@ func TestAccount(t *testing.T) {
 	})
 
 	t.Run("POST store error", func(t *testing.T) {
-		ms := &mockStore{addAccount: func(stores.Account) error { return errStore }}
-		w := doRequest(newTestAPI(ms), http.MethodPost, "/account", stores.Account{Username: "alice"})
+		ms := &mockStore{
+			findWorkgroup: foundWorkgroup(),
+			addAccount:    func(stores.Account) error { return errStore },
+		}
+		w := doRequest(newTestAPI(ms), http.MethodPost, "/account", stores.Account{Username: "alice", Workgroup: testUUID.String()})
 		checkStatus(t, w, http.StatusInternalServerError)
 	})
 
 	t.Run("DELETE removes account", func(t *testing.T) {
 		var gotUser, gotWG string
-		ms := &mockStore{removeAccount: func(u, w string) error { gotUser, gotWG = u, w; return nil }}
+		ms := &mockStore{
+			findWorkgroup: foundWorkgroup(),
+			removeAccount: func(u, w string) error { gotUser, gotWG = u, w; return nil },
+		}
 		w := doRequest(newTestAPI(ms), http.MethodDelete, "/account?username=Alice&workgroup="+testUUID.String(), nil)
 		checkStatus(t, w, http.StatusNoContent)
 		if gotUser != "alice" {
@@ -460,8 +475,11 @@ func TestAccount(t *testing.T) {
 	})
 
 	t.Run("DELETE store error", func(t *testing.T) {
-		ms := &mockStore{removeAccount: func(string, string) error { return errStore }}
-		w := doRequest(newTestAPI(ms), http.MethodDelete, "/account?username=alice", nil)
+		ms := &mockStore{
+			findWorkgroup: foundWorkgroup(),
+			removeAccount: func(string, string) error { return errStore },
+		}
+		w := doRequest(newTestAPI(ms), http.MethodDelete, "/account?username=alice&workgroup="+testUUID.String(), nil)
 		checkStatus(t, w, http.StatusInternalServerError)
 	})
 }
@@ -474,7 +492,8 @@ func TestAccounts(t *testing.T) {
 
 	t.Run("GET returns accounts for workgroup", func(t *testing.T) {
 		ms := &mockStore{
-			findAccounts: func(wg string) ([]stores.Account, error) { return accs, nil },
+			findWorkgroup: foundWorkgroup(),
+			findAccounts:  func(wg string) ([]stores.Account, error) { return accs, nil },
 		}
 		w := doRequest(newTestAPI(ms), http.MethodGet, "/accounts?workgroup="+testUUID.String(), nil)
 		checkStatus(t, w, http.StatusOK)
@@ -485,14 +504,20 @@ func TestAccounts(t *testing.T) {
 	})
 
 	t.Run("GET store error", func(t *testing.T) {
-		ms := &mockStore{findAccounts: func(string) ([]stores.Account, error) { return nil, errStore }}
-		w := doRequest(newTestAPI(ms), http.MethodGet, "/accounts", nil)
+		ms := &mockStore{
+			findWorkgroup: foundWorkgroup(),
+			findAccounts:  func(string) ([]stores.Account, error) { return nil, errStore },
+		}
+		w := doRequest(newTestAPI(ms), http.MethodGet, "/accounts?workgroup="+testUUID.String(), nil)
 		checkStatus(t, w, http.StatusInternalServerError)
 	})
 
 	t.Run("DELETE removes accounts for workgroup", func(t *testing.T) {
 		var gotWG string
-		ms := &mockStore{removeAccounts: func(wg string) error { gotWG = wg; return nil }}
+		ms := &mockStore{
+			findWorkgroup:  foundWorkgroup(),
+			removeAccounts: func(wg string) error { gotWG = wg; return nil },
+		}
 		w := doRequest(newTestAPI(ms), http.MethodDelete, "/accounts?workgroup="+testUUID.String(), nil)
 		checkStatus(t, w, http.StatusNoContent)
 		if gotWG != testUUID.String() {
@@ -501,8 +526,11 @@ func TestAccounts(t *testing.T) {
 	})
 
 	t.Run("DELETE store error", func(t *testing.T) {
-		ms := &mockStore{removeAccounts: func(string) error { return errStore }}
-		w := doRequest(newTestAPI(ms), http.MethodDelete, "/accounts", nil)
+		ms := &mockStore{
+			findWorkgroup:  foundWorkgroup(),
+			removeAccounts: func(string) error { return errStore },
+		}
+		w := doRequest(newTestAPI(ms), http.MethodDelete, "/accounts?workgroup="+testUUID.String(), nil)
 		checkStatus(t, w, http.StatusInternalServerError)
 	})
 }
@@ -621,8 +649,9 @@ func TestShareAccounts(t *testing.T) {
 func TestPolicy(t *testing.T) {
 	t.Run("GET returns access rights", func(t *testing.T) {
 		ms := &mockStore{
-			findAccount: foundAccount("alice", testUUID.String()),
-			getShare:    foundShare("myshare", "renterd"),
+			findWorkgroup: foundWorkgroup(),
+			findAccount:   foundAccount("alice", testUUID.String()),
+			getShare:      foundShare("myshare", "renterd"),
 			getAccessRights: func(stores.Share, stores.Account) (stores.AccessRights, error) {
 				return stores.AccessRights{ShareName: "myshare", AccountID: 1, ReadAccess: true}, nil
 			},
@@ -643,24 +672,27 @@ func TestPolicy(t *testing.T) {
 
 	t.Run("GET findAccount store error", func(t *testing.T) {
 		ms := &mockStore{
-			findAccount: func(string, string) (stores.Account, error) { return stores.Account{}, errStore },
+			findWorkgroup: foundWorkgroup(),
+			findAccount:   func(string, string) (stores.Account, error) { return stores.Account{}, errStore },
 		}
-		w := doRequest(newTestAPI(ms), http.MethodGet, "/share/myshare/policy?username=alice", nil)
+		w := doRequest(newTestAPI(ms), http.MethodGet, "/share/myshare/policy?username=alice&workgroup="+testUUID.String(), nil)
 		checkStatus(t, w, http.StatusInternalServerError)
 	})
 
 	t.Run("GET getShare store error", func(t *testing.T) {
 		ms := &mockStore{
-			findAccount: foundAccount("alice", testUUID.String()),
-			getShare:    func(string) (stores.Share, error) { return stores.Share{}, errStore },
+			findWorkgroup: foundWorkgroup(),
+			findAccount:   foundAccount("alice", testUUID.String()),
+			getShare:      func(string) (stores.Share, error) { return stores.Share{}, errStore },
 		}
-		w := doRequest(newTestAPI(ms), http.MethodGet, "/share/myshare/policy?username=alice", nil)
+		w := doRequest(newTestAPI(ms), http.MethodGet, "/share/myshare/policy?username=alice&workgroup="+testUUID.String(), nil)
 		checkStatus(t, w, http.StatusInternalServerError)
 	})
 
 	t.Run("PUT sets access rights", func(t *testing.T) {
 		var gotAR stores.AccessRights
 		ms := &mockStore{
+			findWorkgroup:   foundWorkgroup(),
 			getShare:        foundShare("myshare", "renterd"),
 			findAccount:     foundAccount("alice", testUUID.String()),
 			setAccessRights: func(ar stores.AccessRights) error { gotAR = ar; return nil },
@@ -694,6 +726,7 @@ func TestPolicy(t *testing.T) {
 
 	t.Run("PUT setAccessRights store error", func(t *testing.T) {
 		ms := &mockStore{
+			findWorkgroup:   foundWorkgroup(),
 			getShare:        foundShare("myshare", "renterd"),
 			findAccount:     foundAccount("alice", testUUID.String()),
 			setAccessRights: func(stores.AccessRights) error { return errStore },
@@ -706,9 +739,10 @@ func TestPolicy(t *testing.T) {
 	t.Run("DELETE removes access rights", func(t *testing.T) {
 		called := false
 		ms := &mockStore{
-			findAccount:  foundAccount("alice", testUUID.String()),
-			getShare:     foundShare("myshare", "renterd"),
-			removeAccess: func(stores.Share, stores.Account) error { called = true; return nil },
+			findWorkgroup: foundWorkgroup(),
+			findAccount:   foundAccount("alice", testUUID.String()),
+			getShare:      foundShare("myshare", "renterd"),
+			removeAccess:  func(stores.Share, stores.Account) error { called = true; return nil },
 		}
 		w := doRequest(newTestAPI(ms), http.MethodDelete,
 			"/share/myshare/policy?username=alice&workgroup="+testUUID.String(), nil)
@@ -725,9 +759,10 @@ func TestPolicy(t *testing.T) {
 
 	t.Run("DELETE store error", func(t *testing.T) {
 		ms := &mockStore{
-			findAccount:  foundAccount("alice", testUUID.String()),
-			getShare:     foundShare("myshare", "renterd"),
-			removeAccess: func(stores.Share, stores.Account) error { return errStore },
+			findWorkgroup: foundWorkgroup(),
+			findAccount:   foundAccount("alice", testUUID.String()),
+			getShare:      foundShare("myshare", "renterd"),
+			removeAccess:  func(stores.Share, stores.Account) error { return errStore },
 		}
 		w := doRequest(newTestAPI(ms), http.MethodDelete,
 			"/share/myshare/policy?username=alice&workgroup="+testUUID.String(), nil)
@@ -743,8 +778,9 @@ func TestAccountShares(t *testing.T) {
 
 	t.Run("GET returns shares without passwords", func(t *testing.T) {
 		ms := &mockStore{
-			findAccount: foundAccount("alice", testUUID.String()),
-			getShares:   func(stores.Account) ([]stores.Share, error) { return shares, nil },
+			findWorkgroup: foundWorkgroup(),
+			findAccount:   foundAccount("alice", testUUID.String()),
+			getShares:     func(stores.Account) ([]stores.Share, error) { return shares, nil },
 		}
 		w := doRequest(newTestAPI(ms), http.MethodGet,
 			"/account/shares?username=alice&workgroup="+testUUID.String(), nil)
@@ -767,18 +803,20 @@ func TestAccountShares(t *testing.T) {
 
 	t.Run("GET getShares store error", func(t *testing.T) {
 		ms := &mockStore{
-			findAccount: foundAccount("alice", testUUID.String()),
-			getShares:   func(stores.Account) ([]stores.Share, error) { return nil, errStore },
+			findWorkgroup: foundWorkgroup(),
+			findAccount:   foundAccount("alice", testUUID.String()),
+			getShares:     func(stores.Account) ([]stores.Share, error) { return nil, errStore },
 		}
-		w := doRequest(newTestAPI(ms), http.MethodGet, "/account/shares?username=alice", nil)
+		w := doRequest(newTestAPI(ms), http.MethodGet, "/account/shares?username=alice&workgroup="+testUUID.String(), nil)
 		checkStatus(t, w, http.StatusInternalServerError)
 	})
 
 	t.Run("DELETE /account/policy clears all access rights", func(t *testing.T) {
 		called := false
 		ms := &mockStore{
-			findAccount: foundAccount("alice", testUUID.String()),
-			clearAccess: func(stores.Account) error { called = true; return nil },
+			findWorkgroup: foundWorkgroup(),
+			findAccount:   foundAccount("alice", testUUID.String()),
+			clearAccess:   func(stores.Account) error { called = true; return nil },
 		}
 		w := doRequest(newTestAPI(ms), http.MethodDelete,
 			"/account/policy?username=alice&workgroup="+testUUID.String(), nil)
@@ -795,10 +833,11 @@ func TestAccountShares(t *testing.T) {
 
 	t.Run("DELETE /account/policy store error", func(t *testing.T) {
 		ms := &mockStore{
-			findAccount: foundAccount("alice", testUUID.String()),
-			clearAccess: func(stores.Account) error { return errStore },
+			findWorkgroup: foundWorkgroup(),
+			findAccount:   foundAccount("alice", testUUID.String()),
+			clearAccess:   func(stores.Account) error { return errStore },
 		}
-		w := doRequest(newTestAPI(ms), http.MethodDelete, "/account/policy?username=alice", nil)
+		w := doRequest(newTestAPI(ms), http.MethodDelete, "/account/policy?username=alice&workgroup="+testUUID.String(), nil)
 		checkStatus(t, w, http.StatusInternalServerError)
 	})
 }

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -789,29 +789,20 @@ func TestWorkgroups(t *testing.T) {
 	t.Run("POST creates workgroup", func(t *testing.T) {
 		var got stores.Workgroup
 		ms := &mockStore{addWorkgroup: func(wg stores.Workgroup) error { got = wg; return nil }}
-		w := doRequest(newTestAPI(ms), http.MethodPost, "/workgroup", map[string]string{"uuid": testUUID.String()})
-		checkStatus(t, w, http.StatusNoContent)
-		if got.UUID != testUUID {
-			t.Errorf("uuid: want %v, got %v", testUUID, got.UUID)
+		w := doRequest(newTestAPI(ms), http.MethodPost, "/workgroup", nil)
+		checkStatus(t, w, http.StatusOK)
+		resp := decodeJSON[WorkgroupResponse](t, w)
+		if resp.UUID == (uuid.UUID{}) {
+			t.Error("expected non-zero UUID in response")
 		}
-	})
-
-	t.Run("POST invalid UUID returns 400", func(t *testing.T) {
-		w := doRequest(newTestAPI(&mockStore{}), http.MethodPost, "/workgroup", map[string]string{"uuid": "not-a-uuid"})
-		checkStatus(t, w, http.StatusBadRequest)
-	})
-
-	t.Run("POST invalid JSON returns 400", func(t *testing.T) {
-		req := httptest.NewRequest(http.MethodPost, "/workgroup", bytes.NewBufferString("{bad}"))
-		req.Header.Set("Content-Type", "application/json")
-		w := httptest.NewRecorder()
-		newTestAPI(&mockStore{}).ServeHTTP(w, req)
-		checkStatus(t, w, http.StatusBadRequest)
+		if got.UUID != resp.UUID {
+			t.Errorf("stored UUID %v does not match response UUID %v", got.UUID, resp.UUID)
+		}
 	})
 
 	t.Run("POST store error", func(t *testing.T) {
 		ms := &mockStore{addWorkgroup: func(stores.Workgroup) error { return errStore }}
-		w := doRequest(newTestAPI(ms), http.MethodPost, "/workgroup", map[string]string{"uuid": testUUID.String()})
+		w := doRequest(newTestAPI(ms), http.MethodPost, "/workgroup", nil)
 		checkStatus(t, w, http.StatusInternalServerError)
 	})
 

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -1,0 +1,1019 @@
+package api
+
+import (
+	"bytes"
+	"context"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/mike76-dev/sombrero/stores"
+	"go.sia.tech/core/types"
+)
+
+var errStore = errors.New("store error")
+
+var testUUID = uuid.MustParse("12345678-1234-1234-1234-123456789abc")
+
+// mockStore implements Store with optional per-method overrides.
+type mockStore struct {
+	isBanned         func(string) (bool, string, error)
+	banHost          func(string, string) error
+	unbanHost        func(string) error
+	clearBans        func() error
+	getAccountByID   func(int) (stores.Account, error)
+	findAccount      func(string, string) (stores.Account, error)
+	addAccount       func(stores.Account) error
+	hasAccount       func(string, string) (bool, error)
+	removeAccount    func(string, string) error
+	findAccounts     func(string) ([]stores.Account, error)
+	removeAccounts   func(string) error
+	addWorkgroup     func(stores.Workgroup) error
+	findWorkgroup    func(uuid.UUID) (stores.Workgroup, error)
+	removeWorkgroup  func(stores.Workgroup) error
+	getAccessRights  func(stores.Share, stores.Account) (stores.AccessRights, error)
+	setAccessRights  func(stores.AccessRights) error
+	removeAccess     func(stores.Share, stores.Account) error
+	clearAccess      func(stores.Account) error
+	registerShare    func(stores.Share) error
+	unregisterShare  func(string) error
+	getShare         func(string) (stores.Share, error)
+	getShares        func(stores.Account) ([]stores.Share, error)
+	getAccounts      func(stores.Share) ([]stores.AccessRights, error)
+	addConnection    func(stores.Workgroup, stores.Share, types.PrivateKey) error
+	removeConnection func(stores.Workgroup, stores.Share) error
+}
+
+func (m *mockStore) IsBanned(h string) (bool, string, error) {
+	if m.isBanned != nil {
+		return m.isBanned(h)
+	}
+	return false, "", nil
+}
+func (m *mockStore) BanHost(h, r string) error {
+	if m.banHost != nil {
+		return m.banHost(h, r)
+	}
+	return nil
+}
+func (m *mockStore) UnbanHost(h string) error {
+	if m.unbanHost != nil {
+		return m.unbanHost(h)
+	}
+	return nil
+}
+func (m *mockStore) ClearBans() error {
+	if m.clearBans != nil {
+		return m.clearBans()
+	}
+	return nil
+}
+func (m *mockStore) GetAccountByID(id int) (stores.Account, error) {
+	if m.getAccountByID != nil {
+		return m.getAccountByID(id)
+	}
+	return stores.Account{}, nil
+}
+func (m *mockStore) FindAccount(u, w string) (stores.Account, error) {
+	if m.findAccount != nil {
+		return m.findAccount(u, w)
+	}
+	return stores.Account{}, nil
+}
+func (m *mockStore) AddAccount(a stores.Account) error {
+	if m.addAccount != nil {
+		return m.addAccount(a)
+	}
+	return nil
+}
+func (m *mockStore) HasAccount(u, w string) (bool, error) {
+	if m.hasAccount != nil {
+		return m.hasAccount(u, w)
+	}
+	return false, nil
+}
+func (m *mockStore) RemoveAccount(u, w string) error {
+	if m.removeAccount != nil {
+		return m.removeAccount(u, w)
+	}
+	return nil
+}
+func (m *mockStore) FindAccounts(w string) ([]stores.Account, error) {
+	if m.findAccounts != nil {
+		return m.findAccounts(w)
+	}
+	return nil, nil
+}
+func (m *mockStore) RemoveAccounts(w string) error {
+	if m.removeAccounts != nil {
+		return m.removeAccounts(w)
+	}
+	return nil
+}
+func (m *mockStore) AddWorkgroup(wg stores.Workgroup) error {
+	if m.addWorkgroup != nil {
+		return m.addWorkgroup(wg)
+	}
+	return nil
+}
+func (m *mockStore) FindWorkgroup(u uuid.UUID) (stores.Workgroup, error) {
+	if m.findWorkgroup != nil {
+		return m.findWorkgroup(u)
+	}
+	return stores.Workgroup{}, nil
+}
+func (m *mockStore) RemoveWorkgroup(wg stores.Workgroup) error {
+	if m.removeWorkgroup != nil {
+		return m.removeWorkgroup(wg)
+	}
+	return nil
+}
+func (m *mockStore) GetAccessRights(s stores.Share, a stores.Account) (stores.AccessRights, error) {
+	if m.getAccessRights != nil {
+		return m.getAccessRights(s, a)
+	}
+	return stores.AccessRights{}, nil
+}
+func (m *mockStore) SetAccessRights(ar stores.AccessRights) error {
+	if m.setAccessRights != nil {
+		return m.setAccessRights(ar)
+	}
+	return nil
+}
+func (m *mockStore) RemoveAccessRights(s stores.Share, a stores.Account) error {
+	if m.removeAccess != nil {
+		return m.removeAccess(s, a)
+	}
+	return nil
+}
+func (m *mockStore) ClearAccessRights(a stores.Account) error {
+	if m.clearAccess != nil {
+		return m.clearAccess(a)
+	}
+	return nil
+}
+func (m *mockStore) RegisterShare(s stores.Share) error {
+	if m.registerShare != nil {
+		return m.registerShare(s)
+	}
+	return nil
+}
+func (m *mockStore) UnregisterShare(n string) error {
+	if m.unregisterShare != nil {
+		return m.unregisterShare(n)
+	}
+	return nil
+}
+func (m *mockStore) GetShare(n string) (stores.Share, error) {
+	if m.getShare != nil {
+		return m.getShare(n)
+	}
+	return stores.Share{}, nil
+}
+func (m *mockStore) GetShares(a stores.Account) ([]stores.Share, error) {
+	if m.getShares != nil {
+		return m.getShares(a)
+	}
+	return nil, nil
+}
+func (m *mockStore) GetAccounts(s stores.Share) ([]stores.AccessRights, error) {
+	if m.getAccounts != nil {
+		return m.getAccounts(s)
+	}
+	return nil, nil
+}
+func (m *mockStore) AddConnection(wg stores.Workgroup, s stores.Share, k types.PrivateKey) error {
+	if m.addConnection != nil {
+		return m.addConnection(wg, s, k)
+	}
+	return nil
+}
+func (m *mockStore) RemoveConnection(wg stores.Workgroup, s stores.Share) error {
+	if m.removeConnection != nil {
+		return m.removeConnection(wg, s)
+	}
+	return nil
+}
+
+func newTestAPI(ms *mockStore) *API {
+	return NewAPI(context.Background(), ms, stores.IndexdConfig{})
+}
+
+func doRequest(api *API, method, path string, body any) *httptest.ResponseRecorder {
+	var req *http.Request
+	if body != nil {
+		b, _ := json.Marshal(body)
+		req = httptest.NewRequest(method, path, bytes.NewReader(b))
+		req.Header.Set("Content-Type", "application/json")
+	} else {
+		req = httptest.NewRequest(method, path, nil)
+	}
+	w := httptest.NewRecorder()
+	api.ServeHTTP(w, req)
+	return w
+}
+
+func checkStatus(t *testing.T, w *httptest.ResponseRecorder, want int) {
+	t.Helper()
+	if w.Code != want {
+		t.Errorf("status: want %d, got %d (body: %s)", want, w.Code, w.Body.String())
+	}
+}
+
+func decodeJSON[T any](t *testing.T, w *httptest.ResponseRecorder) T {
+	t.Helper()
+	var v T
+	if err := json.NewDecoder(w.Body).Decode(&v); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	return v
+}
+
+func foundWorkgroup() func(uuid.UUID) (stores.Workgroup, error) {
+	return func(u uuid.UUID) (stores.Workgroup, error) {
+		if u == testUUID {
+			return stores.Workgroup{ID: 1, UUID: testUUID}, nil
+		}
+		return stores.Workgroup{}, nil
+	}
+}
+
+func foundShare(name, typ string) func(string) (stores.Share, error) {
+	return func(n string) (stores.Share, error) {
+		if n == name {
+			return stores.Share{Name: name, Type: typ, Password: "secret"}, nil
+		}
+		return stores.Share{}, nil
+	}
+}
+
+func foundAccount(username, workgroup string) func(string, string) (stores.Account, error) {
+	return func(u, w string) (stores.Account, error) {
+		if u == username {
+			return stores.Account{ID: 1, Username: u, Workgroup: workgroup}, nil
+		}
+		return stores.Account{}, nil
+	}
+}
+
+func TestBans(t *testing.T) {
+	t.Run("GET not banned", func(t *testing.T) {
+		ms := &mockStore{
+			isBanned: func(h string) (bool, string, error) { return false, "", nil },
+		}
+		w := doRequest(newTestAPI(ms), http.MethodGet, "/ban/1.2.3.4", nil)
+		checkStatus(t, w, http.StatusOK)
+		resp := decodeJSON[IsBannedResponse](t, w)
+		if resp.Banned {
+			t.Error("expected not banned")
+		}
+	})
+
+	t.Run("GET banned", func(t *testing.T) {
+		ms := &mockStore{
+			isBanned: func(h string) (bool, string, error) { return true, "spam", nil },
+		}
+		w := doRequest(newTestAPI(ms), http.MethodGet, "/ban/1.2.3.4", nil)
+		checkStatus(t, w, http.StatusOK)
+		resp := decodeJSON[IsBannedResponse](t, w)
+		if !resp.Banned {
+			t.Error("expected banned")
+		}
+		if resp.Reason != "spam" {
+			t.Errorf("reason: want %q, got %q", "spam", resp.Reason)
+		}
+	})
+
+	t.Run("GET store error", func(t *testing.T) {
+		ms := &mockStore{isBanned: func(string) (bool, string, error) { return false, "", errStore }}
+		w := doRequest(newTestAPI(ms), http.MethodGet, "/ban/1.2.3.4", nil)
+		checkStatus(t, w, http.StatusInternalServerError)
+	})
+
+	t.Run("PUT bans host with reason", func(t *testing.T) {
+		var gotHost, gotReason string
+		ms := &mockStore{
+			banHost: func(h, r string) error { gotHost, gotReason = h, r; return nil },
+		}
+		w := doRequest(newTestAPI(ms), http.MethodPut, "/ban/1.2.3.4?reason=spam", nil)
+		checkStatus(t, w, http.StatusNoContent)
+		if gotHost != "1.2.3.4" {
+			t.Errorf("host: want %q, got %q", "1.2.3.4", gotHost)
+		}
+		if gotReason != "spam" {
+			t.Errorf("reason: want %q, got %q", "spam", gotReason)
+		}
+	})
+
+	t.Run("PUT store error", func(t *testing.T) {
+		ms := &mockStore{banHost: func(string, string) error { return errStore }}
+		w := doRequest(newTestAPI(ms), http.MethodPut, "/ban/1.2.3.4", nil)
+		checkStatus(t, w, http.StatusInternalServerError)
+	})
+
+	t.Run("DELETE unbans host", func(t *testing.T) {
+		var gotHost string
+		ms := &mockStore{unbanHost: func(h string) error { gotHost = h; return nil }}
+		w := doRequest(newTestAPI(ms), http.MethodDelete, "/ban/1.2.3.4", nil)
+		checkStatus(t, w, http.StatusNoContent)
+		if gotHost != "1.2.3.4" {
+			t.Errorf("host: want %q, got %q", "1.2.3.4", gotHost)
+		}
+	})
+
+	t.Run("DELETE store error", func(t *testing.T) {
+		ms := &mockStore{unbanHost: func(string) error { return errStore }}
+		w := doRequest(newTestAPI(ms), http.MethodDelete, "/ban/1.2.3.4", nil)
+		checkStatus(t, w, http.StatusInternalServerError)
+	})
+
+	t.Run("DELETE /bans clears all", func(t *testing.T) {
+		called := false
+		ms := &mockStore{clearBans: func() error { called = true; return nil }}
+		w := doRequest(newTestAPI(ms), http.MethodDelete, "/bans", nil)
+		checkStatus(t, w, http.StatusNoContent)
+		if !called {
+			t.Error("ClearBans not called")
+		}
+	})
+
+	t.Run("DELETE /bans store error", func(t *testing.T) {
+		ms := &mockStore{clearBans: func() error { return errStore }}
+		w := doRequest(newTestAPI(ms), http.MethodDelete, "/bans", nil)
+		checkStatus(t, w, http.StatusInternalServerError)
+	})
+}
+
+func TestAccount(t *testing.T) {
+	t.Run("GET by username", func(t *testing.T) {
+		ms := &mockStore{findAccount: foundAccount("alice", testUUID.String())}
+		w := doRequest(newTestAPI(ms), http.MethodGet, "/account?username=alice&workgroup="+testUUID.String(), nil)
+		checkStatus(t, w, http.StatusOK)
+		acc := decodeJSON[stores.Account](t, w)
+		if acc.Username != "alice" {
+			t.Errorf("username: want %q, got %q", "alice", acc.Username)
+		}
+	})
+
+	t.Run("GET by ID", func(t *testing.T) {
+		ms := &mockStore{
+			getAccountByID: func(id int) (stores.Account, error) {
+				return stores.Account{ID: id, Username: "alice"}, nil
+			},
+		}
+		w := doRequest(newTestAPI(ms), http.MethodGet, "/account?id=1", nil)
+		checkStatus(t, w, http.StatusOK)
+		acc := decodeJSON[stores.Account](t, w)
+		if acc.ID != 1 {
+			t.Errorf("id: want 1, got %d", acc.ID)
+		}
+	})
+
+	t.Run("GET missing username and ID returns 400", func(t *testing.T) {
+		w := doRequest(newTestAPI(&mockStore{}), http.MethodGet, "/account", nil)
+		checkStatus(t, w, http.StatusBadRequest)
+	})
+
+	t.Run("GET invalid ID returns 400", func(t *testing.T) {
+		w := doRequest(newTestAPI(&mockStore{}), http.MethodGet, "/account?id=0", nil)
+		checkStatus(t, w, http.StatusBadRequest)
+	})
+
+	t.Run("GET by username store error", func(t *testing.T) {
+		ms := &mockStore{findAccount: func(string, string) (stores.Account, error) { return stores.Account{}, errStore }}
+		w := doRequest(newTestAPI(ms), http.MethodGet, "/account?username=alice", nil)
+		checkStatus(t, w, http.StatusInternalServerError)
+	})
+
+	t.Run("GET by ID store error", func(t *testing.T) {
+		ms := &mockStore{getAccountByID: func(int) (stores.Account, error) { return stores.Account{}, errStore }}
+		w := doRequest(newTestAPI(ms), http.MethodGet, "/account?id=1", nil)
+		checkStatus(t, w, http.StatusInternalServerError)
+	})
+
+	t.Run("POST creates account", func(t *testing.T) {
+		var got stores.Account
+		ms := &mockStore{addAccount: func(a stores.Account) error { got = a; return nil }}
+		w := doRequest(newTestAPI(ms), http.MethodPost, "/account", stores.Account{
+			Username:  "Alice",
+			Password:  "secret",
+			Workgroup: testUUID.String(),
+		})
+		checkStatus(t, w, http.StatusNoContent)
+		if got.Username != "alice" {
+			t.Errorf("username lowercased: want %q, got %q", "alice", got.Username)
+		}
+	})
+
+	t.Run("POST invalid JSON returns 400", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodPost, "/account", bytes.NewBufferString("not-json"))
+		req.Header.Set("Content-Type", "application/json")
+		w := httptest.NewRecorder()
+		newTestAPI(&mockStore{}).ServeHTTP(w, req)
+		checkStatus(t, w, http.StatusBadRequest)
+	})
+
+	t.Run("POST store error", func(t *testing.T) {
+		ms := &mockStore{addAccount: func(stores.Account) error { return errStore }}
+		w := doRequest(newTestAPI(ms), http.MethodPost, "/account", stores.Account{Username: "alice"})
+		checkStatus(t, w, http.StatusInternalServerError)
+	})
+
+	t.Run("DELETE removes account", func(t *testing.T) {
+		var gotUser, gotWG string
+		ms := &mockStore{removeAccount: func(u, w string) error { gotUser, gotWG = u, w; return nil }}
+		w := doRequest(newTestAPI(ms), http.MethodDelete, "/account?username=Alice&workgroup="+testUUID.String(), nil)
+		checkStatus(t, w, http.StatusNoContent)
+		if gotUser != "alice" {
+			t.Errorf("username lowercased: want %q, got %q", "alice", gotUser)
+		}
+		if gotWG != testUUID.String() {
+			t.Errorf("workgroup: want %q, got %q", testUUID.String(), gotWG)
+		}
+	})
+
+	t.Run("DELETE missing username returns 400", func(t *testing.T) {
+		w := doRequest(newTestAPI(&mockStore{}), http.MethodDelete, "/account", nil)
+		checkStatus(t, w, http.StatusBadRequest)
+	})
+
+	t.Run("DELETE store error", func(t *testing.T) {
+		ms := &mockStore{removeAccount: func(string, string) error { return errStore }}
+		w := doRequest(newTestAPI(ms), http.MethodDelete, "/account?username=alice", nil)
+		checkStatus(t, w, http.StatusInternalServerError)
+	})
+}
+
+func TestAccounts(t *testing.T) {
+	accs := []stores.Account{
+		{ID: 1, Username: "alice", Workgroup: testUUID.String()},
+		{ID: 2, Username: "bob", Workgroup: testUUID.String()},
+	}
+
+	t.Run("GET returns accounts for workgroup", func(t *testing.T) {
+		ms := &mockStore{
+			findAccounts: func(wg string) ([]stores.Account, error) { return accs, nil },
+		}
+		w := doRequest(newTestAPI(ms), http.MethodGet, "/accounts?workgroup="+testUUID.String(), nil)
+		checkStatus(t, w, http.StatusOK)
+		got := decodeJSON[[]stores.Account](t, w)
+		if len(got) != 2 {
+			t.Errorf("want 2 accounts, got %d", len(got))
+		}
+	})
+
+	t.Run("GET store error", func(t *testing.T) {
+		ms := &mockStore{findAccounts: func(string) ([]stores.Account, error) { return nil, errStore }}
+		w := doRequest(newTestAPI(ms), http.MethodGet, "/accounts", nil)
+		checkStatus(t, w, http.StatusInternalServerError)
+	})
+
+	t.Run("DELETE removes accounts for workgroup", func(t *testing.T) {
+		var gotWG string
+		ms := &mockStore{removeAccounts: func(wg string) error { gotWG = wg; return nil }}
+		w := doRequest(newTestAPI(ms), http.MethodDelete, "/accounts?workgroup="+testUUID.String(), nil)
+		checkStatus(t, w, http.StatusNoContent)
+		if gotWG != testUUID.String() {
+			t.Errorf("workgroup: want %q, got %q", testUUID.String(), gotWG)
+		}
+	})
+
+	t.Run("DELETE store error", func(t *testing.T) {
+		ms := &mockStore{removeAccounts: func(string) error { return errStore }}
+		w := doRequest(newTestAPI(ms), http.MethodDelete, "/accounts", nil)
+		checkStatus(t, w, http.StatusInternalServerError)
+	})
+}
+
+func TestShares(t *testing.T) {
+	t.Run("POST registers renterd share", func(t *testing.T) {
+		var got stores.Share
+		ms := &mockStore{registerShare: func(s stores.Share) error { got = s; return nil }}
+		w := doRequest(newTestAPI(ms), http.MethodPost, "/share", stores.Share{
+			Name: "MyShare", Type: "renterd", ServerName: "srv",
+		})
+		checkStatus(t, w, http.StatusNoContent)
+		if got.Name != "myshare" {
+			t.Errorf("name lowercased: want %q, got %q", "myshare", got.Name)
+		}
+		if got.Type != "renterd" {
+			t.Errorf("type: want %q, got %q", "renterd", got.Type)
+		}
+	})
+
+	t.Run("POST registers indexd share", func(t *testing.T) {
+		ms := &mockStore{registerShare: func(s stores.Share) error { return nil }}
+		w := doRequest(newTestAPI(ms), http.MethodPost, "/share", stores.Share{Name: "s2", Type: "indexd"})
+		checkStatus(t, w, http.StatusNoContent)
+	})
+
+	t.Run("POST wrong type returns 400", func(t *testing.T) {
+		w := doRequest(newTestAPI(&mockStore{}), http.MethodPost, "/share", stores.Share{Name: "s", Type: "unknown"})
+		checkStatus(t, w, http.StatusBadRequest)
+	})
+
+	t.Run("POST invalid JSON returns 400", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodPost, "/share", bytes.NewBufferString("{bad}"))
+		req.Header.Set("Content-Type", "application/json")
+		w := httptest.NewRecorder()
+		newTestAPI(&mockStore{}).ServeHTTP(w, req)
+		checkStatus(t, w, http.StatusBadRequest)
+	})
+
+	t.Run("POST store error", func(t *testing.T) {
+		ms := &mockStore{registerShare: func(stores.Share) error { return errStore }}
+		w := doRequest(newTestAPI(ms), http.MethodPost, "/share", stores.Share{Name: "s", Type: "renterd"})
+		checkStatus(t, w, http.StatusInternalServerError)
+	})
+
+	t.Run("GET returns share without password", func(t *testing.T) {
+		ms := &mockStore{getShare: foundShare("myshare", "renterd")}
+		w := doRequest(newTestAPI(ms), http.MethodGet, "/share/myshare", nil)
+		checkStatus(t, w, http.StatusOK)
+		sh := decodeJSON[stores.Share](t, w)
+		if sh.Name != "myshare" {
+			t.Errorf("name: want %q, got %q", "myshare", sh.Name)
+		}
+		if sh.Password != "" {
+			t.Error("password must not be exposed")
+		}
+	})
+
+	t.Run("GET store error", func(t *testing.T) {
+		ms := &mockStore{getShare: func(string) (stores.Share, error) { return stores.Share{}, errStore }}
+		w := doRequest(newTestAPI(ms), http.MethodGet, "/share/myshare", nil)
+		checkStatus(t, w, http.StatusInternalServerError)
+	})
+
+	t.Run("DELETE unregisters share", func(t *testing.T) {
+		var gotName string
+		ms := &mockStore{unregisterShare: func(n string) error { gotName = n; return nil }}
+		w := doRequest(newTestAPI(ms), http.MethodDelete, "/share/myshare", nil)
+		checkStatus(t, w, http.StatusNoContent)
+		if gotName != "myshare" {
+			t.Errorf("name: want %q, got %q", "myshare", gotName)
+		}
+	})
+
+	t.Run("DELETE store error", func(t *testing.T) {
+		ms := &mockStore{unregisterShare: func(string) error { return errStore }}
+		w := doRequest(newTestAPI(ms), http.MethodDelete, "/share/myshare", nil)
+		checkStatus(t, w, http.StatusInternalServerError)
+	})
+}
+
+func TestShareAccounts(t *testing.T) {
+	ars := []stores.AccessRights{
+		{ShareName: "myshare", AccountID: 1, ReadAccess: true},
+	}
+
+	t.Run("GET returns access rights", func(t *testing.T) {
+		ms := &mockStore{
+			getShare:    foundShare("myshare", "renterd"),
+			getAccounts: func(stores.Share) ([]stores.AccessRights, error) { return ars, nil },
+		}
+		w := doRequest(newTestAPI(ms), http.MethodGet, "/share/myshare/accounts", nil)
+		checkStatus(t, w, http.StatusOK)
+		got := decodeJSON[[]stores.AccessRights](t, w)
+		if len(got) != 1 {
+			t.Errorf("want 1, got %d", len(got))
+		}
+	})
+
+	t.Run("GET getShare store error", func(t *testing.T) {
+		ms := &mockStore{getShare: func(string) (stores.Share, error) { return stores.Share{}, errStore }}
+		w := doRequest(newTestAPI(ms), http.MethodGet, "/share/myshare/accounts", nil)
+		checkStatus(t, w, http.StatusInternalServerError)
+	})
+
+	t.Run("GET getAccounts store error", func(t *testing.T) {
+		ms := &mockStore{
+			getShare:    foundShare("myshare", "renterd"),
+			getAccounts: func(stores.Share) ([]stores.AccessRights, error) { return nil, errStore },
+		}
+		w := doRequest(newTestAPI(ms), http.MethodGet, "/share/myshare/accounts", nil)
+		checkStatus(t, w, http.StatusInternalServerError)
+	})
+}
+
+func TestPolicy(t *testing.T) {
+	t.Run("GET returns access rights", func(t *testing.T) {
+		ms := &mockStore{
+			findAccount: foundAccount("alice", testUUID.String()),
+			getShare:    foundShare("myshare", "renterd"),
+			getAccessRights: func(stores.Share, stores.Account) (stores.AccessRights, error) {
+				return stores.AccessRights{ShareName: "myshare", AccountID: 1, ReadAccess: true}, nil
+			},
+		}
+		w := doRequest(newTestAPI(ms), http.MethodGet,
+			"/share/myshare/policy?username=alice&workgroup="+testUUID.String(), nil)
+		checkStatus(t, w, http.StatusOK)
+		ar := decodeJSON[stores.AccessRights](t, w)
+		if !ar.ReadAccess {
+			t.Error("expected ReadAccess true")
+		}
+	})
+
+	t.Run("GET missing username returns 400", func(t *testing.T) {
+		w := doRequest(newTestAPI(&mockStore{}), http.MethodGet, "/share/myshare/policy", nil)
+		checkStatus(t, w, http.StatusBadRequest)
+	})
+
+	t.Run("GET findAccount store error", func(t *testing.T) {
+		ms := &mockStore{
+			findAccount: func(string, string) (stores.Account, error) { return stores.Account{}, errStore },
+		}
+		w := doRequest(newTestAPI(ms), http.MethodGet, "/share/myshare/policy?username=alice", nil)
+		checkStatus(t, w, http.StatusInternalServerError)
+	})
+
+	t.Run("GET getShare store error", func(t *testing.T) {
+		ms := &mockStore{
+			findAccount: foundAccount("alice", testUUID.String()),
+			getShare:    func(string) (stores.Share, error) { return stores.Share{}, errStore },
+		}
+		w := doRequest(newTestAPI(ms), http.MethodGet, "/share/myshare/policy?username=alice", nil)
+		checkStatus(t, w, http.StatusInternalServerError)
+	})
+
+	t.Run("PUT sets access rights", func(t *testing.T) {
+		var gotAR stores.AccessRights
+		ms := &mockStore{
+			getShare:        foundShare("myshare", "renterd"),
+			findAccount:     foundAccount("alice", testUUID.String()),
+			setAccessRights: func(ar stores.AccessRights) error { gotAR = ar; return nil },
+		}
+		w := doRequest(newTestAPI(ms), http.MethodPut,
+			"/share/myshare/policy?username=alice&workgroup="+testUUID.String()+"&read=true&write=true", nil)
+		checkStatus(t, w, http.StatusNoContent)
+		if !gotAR.ReadAccess {
+			t.Error("expected ReadAccess true")
+		}
+		if !gotAR.WriteAccess {
+			t.Error("expected WriteAccess true")
+		}
+		if gotAR.DeleteAccess {
+			t.Error("expected DeleteAccess false")
+		}
+	})
+
+	t.Run("PUT share not found returns 400", func(t *testing.T) {
+		ms := &mockStore{getShare: func(string) (stores.Share, error) { return stores.Share{}, nil }}
+		w := doRequest(newTestAPI(ms), http.MethodPut,
+			"/share/missing/policy?username=alice&workgroup="+testUUID.String(), nil)
+		checkStatus(t, w, http.StatusBadRequest)
+	})
+
+	t.Run("PUT missing username returns 400", func(t *testing.T) {
+		ms := &mockStore{getShare: foundShare("myshare", "renterd")}
+		w := doRequest(newTestAPI(ms), http.MethodPut, "/share/myshare/policy", nil)
+		checkStatus(t, w, http.StatusBadRequest)
+	})
+
+	t.Run("PUT setAccessRights store error", func(t *testing.T) {
+		ms := &mockStore{
+			getShare:        foundShare("myshare", "renterd"),
+			findAccount:     foundAccount("alice", testUUID.String()),
+			setAccessRights: func(stores.AccessRights) error { return errStore },
+		}
+		w := doRequest(newTestAPI(ms), http.MethodPut,
+			"/share/myshare/policy?username=alice&workgroup="+testUUID.String(), nil)
+		checkStatus(t, w, http.StatusInternalServerError)
+	})
+
+	t.Run("DELETE removes access rights", func(t *testing.T) {
+		called := false
+		ms := &mockStore{
+			findAccount:  foundAccount("alice", testUUID.String()),
+			getShare:     foundShare("myshare", "renterd"),
+			removeAccess: func(stores.Share, stores.Account) error { called = true; return nil },
+		}
+		w := doRequest(newTestAPI(ms), http.MethodDelete,
+			"/share/myshare/policy?username=alice&workgroup="+testUUID.String(), nil)
+		checkStatus(t, w, http.StatusNoContent)
+		if !called {
+			t.Error("RemoveAccessRights not called")
+		}
+	})
+
+	t.Run("DELETE missing username returns 400", func(t *testing.T) {
+		w := doRequest(newTestAPI(&mockStore{}), http.MethodDelete, "/share/myshare/policy", nil)
+		checkStatus(t, w, http.StatusBadRequest)
+	})
+
+	t.Run("DELETE store error", func(t *testing.T) {
+		ms := &mockStore{
+			findAccount:  foundAccount("alice", testUUID.String()),
+			getShare:     foundShare("myshare", "renterd"),
+			removeAccess: func(stores.Share, stores.Account) error { return errStore },
+		}
+		w := doRequest(newTestAPI(ms), http.MethodDelete,
+			"/share/myshare/policy?username=alice&workgroup="+testUUID.String(), nil)
+		checkStatus(t, w, http.StatusInternalServerError)
+	})
+}
+
+func TestAccountShares(t *testing.T) {
+	shares := []stores.Share{
+		{Name: "s1", Type: "renterd", Password: "secret1"},
+		{Name: "s2", Type: "indexd", Password: "secret2"},
+	}
+
+	t.Run("GET returns shares without passwords", func(t *testing.T) {
+		ms := &mockStore{
+			findAccount: foundAccount("alice", testUUID.String()),
+			getShares:   func(stores.Account) ([]stores.Share, error) { return shares, nil },
+		}
+		w := doRequest(newTestAPI(ms), http.MethodGet,
+			"/account/shares?username=alice&workgroup="+testUUID.String(), nil)
+		checkStatus(t, w, http.StatusOK)
+		got := decodeJSON[[]stores.Share](t, w)
+		if len(got) != 2 {
+			t.Errorf("want 2 shares, got %d", len(got))
+		}
+		for _, sh := range got {
+			if sh.Password != "" {
+				t.Errorf("share %q: password must not be exposed", sh.Name)
+			}
+		}
+	})
+
+	t.Run("GET missing username returns 400", func(t *testing.T) {
+		w := doRequest(newTestAPI(&mockStore{}), http.MethodGet, "/account/shares", nil)
+		checkStatus(t, w, http.StatusBadRequest)
+	})
+
+	t.Run("GET getShares store error", func(t *testing.T) {
+		ms := &mockStore{
+			findAccount: foundAccount("alice", testUUID.String()),
+			getShares:   func(stores.Account) ([]stores.Share, error) { return nil, errStore },
+		}
+		w := doRequest(newTestAPI(ms), http.MethodGet, "/account/shares?username=alice", nil)
+		checkStatus(t, w, http.StatusInternalServerError)
+	})
+
+	t.Run("DELETE /account/policy clears all access rights", func(t *testing.T) {
+		called := false
+		ms := &mockStore{
+			findAccount: foundAccount("alice", testUUID.String()),
+			clearAccess: func(stores.Account) error { called = true; return nil },
+		}
+		w := doRequest(newTestAPI(ms), http.MethodDelete,
+			"/account/policy?username=alice&workgroup="+testUUID.String(), nil)
+		checkStatus(t, w, http.StatusNoContent)
+		if !called {
+			t.Error("ClearAccessRights not called")
+		}
+	})
+
+	t.Run("DELETE /account/policy missing username returns 400", func(t *testing.T) {
+		w := doRequest(newTestAPI(&mockStore{}), http.MethodDelete, "/account/policy", nil)
+		checkStatus(t, w, http.StatusBadRequest)
+	})
+
+	t.Run("DELETE /account/policy store error", func(t *testing.T) {
+		ms := &mockStore{
+			findAccount: foundAccount("alice", testUUID.String()),
+			clearAccess: func(stores.Account) error { return errStore },
+		}
+		w := doRequest(newTestAPI(ms), http.MethodDelete, "/account/policy?username=alice", nil)
+		checkStatus(t, w, http.StatusInternalServerError)
+	})
+}
+
+func TestWorkgroups(t *testing.T) {
+	t.Run("POST creates workgroup", func(t *testing.T) {
+		var got stores.Workgroup
+		ms := &mockStore{addWorkgroup: func(wg stores.Workgroup) error { got = wg; return nil }}
+		w := doRequest(newTestAPI(ms), http.MethodPost, "/workgroup", map[string]string{"uuid": testUUID.String()})
+		checkStatus(t, w, http.StatusNoContent)
+		if got.UUID != testUUID {
+			t.Errorf("uuid: want %v, got %v", testUUID, got.UUID)
+		}
+	})
+
+	t.Run("POST invalid UUID returns 400", func(t *testing.T) {
+		w := doRequest(newTestAPI(&mockStore{}), http.MethodPost, "/workgroup", map[string]string{"uuid": "not-a-uuid"})
+		checkStatus(t, w, http.StatusBadRequest)
+	})
+
+	t.Run("POST invalid JSON returns 400", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodPost, "/workgroup", bytes.NewBufferString("{bad}"))
+		req.Header.Set("Content-Type", "application/json")
+		w := httptest.NewRecorder()
+		newTestAPI(&mockStore{}).ServeHTTP(w, req)
+		checkStatus(t, w, http.StatusBadRequest)
+	})
+
+	t.Run("POST store error", func(t *testing.T) {
+		ms := &mockStore{addWorkgroup: func(stores.Workgroup) error { return errStore }}
+		w := doRequest(newTestAPI(ms), http.MethodPost, "/workgroup", map[string]string{"uuid": testUUID.String()})
+		checkStatus(t, w, http.StatusInternalServerError)
+	})
+
+	t.Run("GET returns workgroup", func(t *testing.T) {
+		ms := &mockStore{findWorkgroup: foundWorkgroup()}
+		w := doRequest(newTestAPI(ms), http.MethodGet, "/workgroup/"+testUUID.String(), nil)
+		checkStatus(t, w, http.StatusOK)
+		wg := decodeJSON[stores.Workgroup](t, w)
+		if wg.UUID != testUUID {
+			t.Errorf("uuid: want %v, got %v", testUUID, wg.UUID)
+		}
+	})
+
+	t.Run("GET not found returns 404", func(t *testing.T) {
+		ms := &mockStore{findWorkgroup: func(uuid.UUID) (stores.Workgroup, error) { return stores.Workgroup{}, nil }}
+		other := uuid.MustParse("00000000-0000-0000-0000-000000000001")
+		w := doRequest(newTestAPI(ms), http.MethodGet, "/workgroup/"+other.String(), nil)
+		checkStatus(t, w, http.StatusNotFound)
+	})
+
+	t.Run("GET invalid UUID returns 400", func(t *testing.T) {
+		w := doRequest(newTestAPI(&mockStore{}), http.MethodGet, "/workgroup/not-a-uuid", nil)
+		checkStatus(t, w, http.StatusBadRequest)
+	})
+
+	t.Run("GET store error", func(t *testing.T) {
+		ms := &mockStore{findWorkgroup: func(uuid.UUID) (stores.Workgroup, error) { return stores.Workgroup{}, errStore }}
+		w := doRequest(newTestAPI(ms), http.MethodGet, "/workgroup/"+testUUID.String(), nil)
+		checkStatus(t, w, http.StatusInternalServerError)
+	})
+
+	t.Run("DELETE removes workgroup", func(t *testing.T) {
+		called := false
+		ms := &mockStore{
+			findWorkgroup:   foundWorkgroup(),
+			removeWorkgroup: func(stores.Workgroup) error { called = true; return nil },
+		}
+		w := doRequest(newTestAPI(ms), http.MethodDelete, "/workgroup/"+testUUID.String(), nil)
+		checkStatus(t, w, http.StatusNoContent)
+		if !called {
+			t.Error("RemoveWorkgroup not called")
+		}
+	})
+
+	t.Run("DELETE not found returns 404", func(t *testing.T) {
+		ms := &mockStore{findWorkgroup: func(uuid.UUID) (stores.Workgroup, error) { return stores.Workgroup{}, nil }}
+		w := doRequest(newTestAPI(ms), http.MethodDelete, "/workgroup/"+testUUID.String(), nil)
+		checkStatus(t, w, http.StatusNotFound)
+	})
+
+	t.Run("DELETE invalid UUID returns 400", func(t *testing.T) {
+		w := doRequest(newTestAPI(&mockStore{}), http.MethodDelete, "/workgroup/bad-uuid", nil)
+		checkStatus(t, w, http.StatusBadRequest)
+	})
+
+	t.Run("DELETE store error", func(t *testing.T) {
+		ms := &mockStore{
+			findWorkgroup:   foundWorkgroup(),
+			removeWorkgroup: func(stores.Workgroup) error { return errStore },
+		}
+		w := doRequest(newTestAPI(ms), http.MethodDelete, "/workgroup/"+testUUID.String(), nil)
+		checkStatus(t, w, http.StatusInternalServerError)
+	})
+}
+
+func TestConnect(t *testing.T) {
+	path := "/connect/" + testUUID.String() + "/myshare"
+
+	t.Run("PUT connects workgroup to renterd share (no body)", func(t *testing.T) {
+		called := false
+		ms := &mockStore{
+			findWorkgroup: foundWorkgroup(),
+			getShare:      foundShare("myshare", "renterd"),
+			addConnection: func(stores.Workgroup, stores.Share, types.PrivateKey) error {
+				called = true
+				return nil
+			},
+		}
+		w := doRequest(newTestAPI(ms), http.MethodPut, path, nil)
+		checkStatus(t, w, http.StatusNoContent)
+		if !called {
+			t.Error("AddConnection not called")
+		}
+	})
+
+	t.Run("PUT connects workgroup to indexd share with app key", func(t *testing.T) {
+		appKey := make([]byte, 64)
+		for i := range appKey {
+			appKey[i] = byte(i)
+		}
+		var gotKey types.PrivateKey
+		ms := &mockStore{
+			findWorkgroup: foundWorkgroup(),
+			getShare:      foundShare("myshare", "indexd"),
+			addConnection: func(_ stores.Workgroup, _ stores.Share, k types.PrivateKey) error {
+				gotKey = k
+				return nil
+			},
+		}
+		body := map[string]string{"appKey": hex.EncodeToString(appKey)}
+		w := doRequest(newTestAPI(ms), http.MethodPut, path, body)
+		checkStatus(t, w, http.StatusNoContent)
+		if len(gotKey) != 64 {
+			t.Errorf("app key length: want 64, got %d", len(gotKey))
+		}
+		if gotKey[1] != 1 {
+			t.Errorf("app key[1]: want 1, got %d", gotKey[1])
+		}
+	})
+
+	t.Run("PUT invalid workgroup UUID returns 400", func(t *testing.T) {
+		w := doRequest(newTestAPI(&mockStore{}), http.MethodPut, "/connect/bad-uuid/myshare", nil)
+		checkStatus(t, w, http.StatusBadRequest)
+	})
+
+	t.Run("PUT workgroup not found returns 404", func(t *testing.T) {
+		ms := &mockStore{findWorkgroup: func(uuid.UUID) (stores.Workgroup, error) { return stores.Workgroup{}, nil }}
+		w := doRequest(newTestAPI(ms), http.MethodPut, path, nil)
+		checkStatus(t, w, http.StatusNotFound)
+	})
+
+	t.Run("PUT share not found returns 404", func(t *testing.T) {
+		ms := &mockStore{
+			findWorkgroup: foundWorkgroup(),
+			getShare:      func(string) (stores.Share, error) { return stores.Share{}, nil },
+		}
+		w := doRequest(newTestAPI(ms), http.MethodPut, path, nil)
+		checkStatus(t, w, http.StatusNotFound)
+	})
+
+	t.Run("PUT invalid appKey hex returns 400", func(t *testing.T) {
+		ms := &mockStore{
+			findWorkgroup: foundWorkgroup(),
+			getShare:      foundShare("myshare", "indexd"),
+		}
+		w := doRequest(newTestAPI(ms), http.MethodPut, path, map[string]string{"appKey": "not-hex!!"})
+		checkStatus(t, w, http.StatusBadRequest)
+	})
+
+	t.Run("PUT invalid JSON body returns 400", func(t *testing.T) {
+		ms := &mockStore{
+			findWorkgroup: foundWorkgroup(),
+			getShare:      foundShare("myshare", "indexd"),
+		}
+		req := httptest.NewRequest(http.MethodPut, path, bytes.NewBufferString("{bad}"))
+		req.Header.Set("Content-Type", "application/json")
+		w := httptest.NewRecorder()
+		newTestAPI(ms).ServeHTTP(w, req)
+		checkStatus(t, w, http.StatusBadRequest)
+	})
+
+	t.Run("PUT store error", func(t *testing.T) {
+		ms := &mockStore{
+			findWorkgroup: foundWorkgroup(),
+			getShare:      foundShare("myshare", "renterd"),
+			addConnection: func(stores.Workgroup, stores.Share, types.PrivateKey) error { return errStore },
+		}
+		w := doRequest(newTestAPI(ms), http.MethodPut, path, nil)
+		checkStatus(t, w, http.StatusInternalServerError)
+	})
+
+	t.Run("DELETE disconnects workgroup from share", func(t *testing.T) {
+		called := false
+		ms := &mockStore{
+			findWorkgroup:    foundWorkgroup(),
+			getShare:         foundShare("myshare", "renterd"),
+			removeConnection: func(stores.Workgroup, stores.Share) error { called = true; return nil },
+		}
+		w := doRequest(newTestAPI(ms), http.MethodDelete, path, nil)
+		checkStatus(t, w, http.StatusNoContent)
+		if !called {
+			t.Error("RemoveConnection not called")
+		}
+	})
+
+	t.Run("DELETE invalid workgroup UUID returns 400", func(t *testing.T) {
+		w := doRequest(newTestAPI(&mockStore{}), http.MethodDelete, "/connect/bad-uuid/myshare", nil)
+		checkStatus(t, w, http.StatusBadRequest)
+	})
+
+	t.Run("DELETE workgroup not found returns 404", func(t *testing.T) {
+		ms := &mockStore{findWorkgroup: func(uuid.UUID) (stores.Workgroup, error) { return stores.Workgroup{}, nil }}
+		w := doRequest(newTestAPI(ms), http.MethodDelete, path, nil)
+		checkStatus(t, w, http.StatusNotFound)
+	})
+
+	t.Run("DELETE share not found returns 404", func(t *testing.T) {
+		ms := &mockStore{
+			findWorkgroup: foundWorkgroup(),
+			getShare:      func(string) (stores.Share, error) { return stores.Share{}, nil },
+		}
+		w := doRequest(newTestAPI(ms), http.MethodDelete, path, nil)
+		checkStatus(t, w, http.StatusNotFound)
+	})
+
+	t.Run("DELETE store error", func(t *testing.T) {
+		ms := &mockStore{
+			findWorkgroup:    foundWorkgroup(),
+			getShare:         foundShare("myshare", "renterd"),
+			removeConnection: func(stores.Workgroup, stores.Share) error { return errStore },
+		}
+		w := doRequest(newTestAPI(ms), http.MethodDelete, path, nil)
+		checkStatus(t, w, http.StatusInternalServerError)
+	})
+}

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -32,9 +32,10 @@ type mockStore struct {
 	removeAccount    func(string, string) error
 	findAccounts     func(string) ([]stores.Account, error)
 	removeAccounts   func(string) error
-	addWorkgroup     func(stores.Workgroup) error
-	findWorkgroup    func(uuid.UUID) (stores.Workgroup, error)
-	removeWorkgroup  func(stores.Workgroup) error
+	addWorkgroup          func(stores.Workgroup) error
+	findWorkgroup         func(uuid.UUID) (stores.Workgroup, error)
+	findWorkgroupByName   func(string) (stores.Workgroup, error)
+	removeWorkgroup       func(stores.Workgroup) error
 	getAccessRights  func(stores.Share, stores.Account) (stores.AccessRights, error)
 	setAccessRights  func(stores.AccessRights) error
 	removeAccess     func(stores.Share, stores.Account) error
@@ -123,6 +124,12 @@ func (m *mockStore) AddWorkgroup(wg stores.Workgroup) error {
 func (m *mockStore) FindWorkgroup(u uuid.UUID) (stores.Workgroup, error) {
 	if m.findWorkgroup != nil {
 		return m.findWorkgroup(u)
+	}
+	return stores.Workgroup{}, nil
+}
+func (m *mockStore) FindWorkgroupByName(name string) (stores.Workgroup, error) {
+	if m.findWorkgroupByName != nil {
+		return m.findWorkgroupByName(name)
 	}
 	return stores.Workgroup{}, nil
 }
@@ -233,10 +240,21 @@ func decodeJSON[T any](t *testing.T, w *httptest.ResponseRecorder) T {
 	return v
 }
 
+const testWorkgroupName = "acme"
+
 func foundWorkgroup() func(uuid.UUID) (stores.Workgroup, error) {
 	return func(u uuid.UUID) (stores.Workgroup, error) {
 		if u == testUUID {
-			return stores.Workgroup{ID: 1, UUID: testUUID}, nil
+			return stores.Workgroup{ID: 1, UUID: testUUID, Name: testWorkgroupName}, nil
+		}
+		return stores.Workgroup{}, nil
+	}
+}
+
+func foundWorkgroupByName() func(string) (stores.Workgroup, error) {
+	return func(name string) (stores.Workgroup, error) {
+		if name == testWorkgroupName {
+			return stores.Workgroup{ID: 1, UUID: testUUID, Name: testWorkgroupName}, nil
 		}
 		return stores.Workgroup{}, nil
 	}
@@ -786,7 +804,7 @@ func TestAccountShares(t *testing.T) {
 }
 
 func TestWorkgroups(t *testing.T) {
-	t.Run("POST creates workgroup", func(t *testing.T) {
+	t.Run("POST creates workgroup without name", func(t *testing.T) {
 		var got stores.Workgroup
 		ms := &mockStore{addWorkgroup: func(wg stores.Workgroup) error { got = wg; return nil }}
 		w := doRequest(newTestAPI(ms), http.MethodPost, "/workgroup", nil)
@@ -798,6 +816,26 @@ func TestWorkgroups(t *testing.T) {
 		if got.UUID != resp.UUID {
 			t.Errorf("stored UUID %v does not match response UUID %v", got.UUID, resp.UUID)
 		}
+		if resp.Name != "" {
+			t.Errorf("expected empty name, got %q", resp.Name)
+		}
+	})
+
+	t.Run("POST creates workgroup with name", func(t *testing.T) {
+		var got stores.Workgroup
+		ms := &mockStore{addWorkgroup: func(wg stores.Workgroup) error { got = wg; return nil }}
+		w := doRequest(newTestAPI(ms), http.MethodPost, "/workgroup", map[string]string{"name": "acme"})
+		checkStatus(t, w, http.StatusOK)
+		resp := decodeJSON[WorkgroupResponse](t, w)
+		if resp.UUID == (uuid.UUID{}) {
+			t.Error("expected non-zero UUID in response")
+		}
+		if resp.Name != "acme" {
+			t.Errorf("name: want %q, got %q", "acme", resp.Name)
+		}
+		if got.Name != "acme" {
+			t.Errorf("stored name: want %q, got %q", "acme", got.Name)
+		}
 	})
 
 	t.Run("POST store error", func(t *testing.T) {
@@ -806,7 +844,7 @@ func TestWorkgroups(t *testing.T) {
 		checkStatus(t, w, http.StatusInternalServerError)
 	})
 
-	t.Run("GET returns workgroup", func(t *testing.T) {
+	t.Run("GET returns workgroup by UUID", func(t *testing.T) {
 		ms := &mockStore{findWorkgroup: foundWorkgroup()}
 		w := doRequest(newTestAPI(ms), http.MethodGet, "/workgroup/"+testUUID.String(), nil)
 		checkStatus(t, w, http.StatusOK)
@@ -816,25 +854,41 @@ func TestWorkgroups(t *testing.T) {
 		}
 	})
 
-	t.Run("GET not found returns 404", func(t *testing.T) {
+	t.Run("GET returns workgroup by name", func(t *testing.T) {
+		ms := &mockStore{findWorkgroupByName: foundWorkgroupByName()}
+		w := doRequest(newTestAPI(ms), http.MethodGet, "/workgroup/"+testWorkgroupName, nil)
+		checkStatus(t, w, http.StatusOK)
+		wg := decodeJSON[stores.Workgroup](t, w)
+		if wg.Name != testWorkgroupName {
+			t.Errorf("name: want %q, got %q", testWorkgroupName, wg.Name)
+		}
+	})
+
+	t.Run("GET not found by UUID returns 404", func(t *testing.T) {
 		ms := &mockStore{findWorkgroup: func(uuid.UUID) (stores.Workgroup, error) { return stores.Workgroup{}, nil }}
 		other := uuid.MustParse("00000000-0000-0000-0000-000000000001")
 		w := doRequest(newTestAPI(ms), http.MethodGet, "/workgroup/"+other.String(), nil)
 		checkStatus(t, w, http.StatusNotFound)
 	})
 
-	t.Run("GET invalid UUID returns 400", func(t *testing.T) {
-		w := doRequest(newTestAPI(&mockStore{}), http.MethodGet, "/workgroup/not-a-uuid", nil)
-		checkStatus(t, w, http.StatusBadRequest)
+	t.Run("GET not found by name returns 404", func(t *testing.T) {
+		w := doRequest(newTestAPI(&mockStore{}), http.MethodGet, "/workgroup/unknown-name", nil)
+		checkStatus(t, w, http.StatusNotFound)
 	})
 
-	t.Run("GET store error", func(t *testing.T) {
+	t.Run("GET store error by UUID", func(t *testing.T) {
 		ms := &mockStore{findWorkgroup: func(uuid.UUID) (stores.Workgroup, error) { return stores.Workgroup{}, errStore }}
 		w := doRequest(newTestAPI(ms), http.MethodGet, "/workgroup/"+testUUID.String(), nil)
 		checkStatus(t, w, http.StatusInternalServerError)
 	})
 
-	t.Run("DELETE removes workgroup", func(t *testing.T) {
+	t.Run("GET store error by name", func(t *testing.T) {
+		ms := &mockStore{findWorkgroupByName: func(string) (stores.Workgroup, error) { return stores.Workgroup{}, errStore }}
+		w := doRequest(newTestAPI(ms), http.MethodGet, "/workgroup/unknown-name", nil)
+		checkStatus(t, w, http.StatusInternalServerError)
+	})
+
+	t.Run("DELETE removes workgroup by UUID", func(t *testing.T) {
 		called := false
 		ms := &mockStore{
 			findWorkgroup:   foundWorkgroup(),
@@ -847,15 +901,23 @@ func TestWorkgroups(t *testing.T) {
 		}
 	})
 
+	t.Run("DELETE removes workgroup by name", func(t *testing.T) {
+		called := false
+		ms := &mockStore{
+			findWorkgroupByName: foundWorkgroupByName(),
+			removeWorkgroup:     func(stores.Workgroup) error { called = true; return nil },
+		}
+		w := doRequest(newTestAPI(ms), http.MethodDelete, "/workgroup/"+testWorkgroupName, nil)
+		checkStatus(t, w, http.StatusNoContent)
+		if !called {
+			t.Error("RemoveWorkgroup not called")
+		}
+	})
+
 	t.Run("DELETE not found returns 404", func(t *testing.T) {
 		ms := &mockStore{findWorkgroup: func(uuid.UUID) (stores.Workgroup, error) { return stores.Workgroup{}, nil }}
 		w := doRequest(newTestAPI(ms), http.MethodDelete, "/workgroup/"+testUUID.String(), nil)
 		checkStatus(t, w, http.StatusNotFound)
-	})
-
-	t.Run("DELETE invalid UUID returns 400", func(t *testing.T) {
-		w := doRequest(newTestAPI(&mockStore{}), http.MethodDelete, "/workgroup/bad-uuid", nil)
-		checkStatus(t, w, http.StatusBadRequest)
 	})
 
 	t.Run("DELETE store error", func(t *testing.T) {
@@ -874,12 +936,12 @@ func TestWorkgroups(t *testing.T) {
 func TestConnectRequest(t *testing.T) {
 	requestPath := "/connect/" + testUUID.String() + "/myshare"
 
-	t.Run("POST invalid workgroup UUID returns 400", func(t *testing.T) {
-		w := doRequest(newTestAPI(&mockStore{}), http.MethodPost, "/connect/bad-uuid/myshare", nil)
-		checkStatus(t, w, http.StatusBadRequest)
+	t.Run("POST unknown workgroup returns 404", func(t *testing.T) {
+		w := doRequest(newTestAPI(&mockStore{}), http.MethodPost, "/connect/unknown-name/myshare", nil)
+		checkStatus(t, w, http.StatusNotFound)
 	})
 
-	t.Run("POST workgroup not found returns 404", func(t *testing.T) {
+	t.Run("POST workgroup not found by UUID returns 404", func(t *testing.T) {
 		ms := &mockStore{findWorkgroup: func(uuid.UUID) (stores.Workgroup, error) { return stores.Workgroup{}, nil }}
 		w := doRequest(newTestAPI(ms), http.MethodPost, requestPath, nil)
 		checkStatus(t, w, http.StatusNotFound)
@@ -968,12 +1030,12 @@ func TestConnect(t *testing.T) {
 		}
 	})
 
-	t.Run("PUT invalid workgroup UUID returns 400", func(t *testing.T) {
-		w := doRequest(newTestAPI(&mockStore{}), http.MethodPut, "/connect/bad-uuid/myshare", nil)
-		checkStatus(t, w, http.StatusBadRequest)
+	t.Run("PUT unknown workgroup returns 404", func(t *testing.T) {
+		w := doRequest(newTestAPI(&mockStore{}), http.MethodPut, "/connect/unknown-name/myshare", nil)
+		checkStatus(t, w, http.StatusNotFound)
 	})
 
-	t.Run("PUT workgroup not found returns 404", func(t *testing.T) {
+	t.Run("PUT workgroup not found by UUID returns 404", func(t *testing.T) {
 		ms := &mockStore{findWorkgroup: func(uuid.UUID) (stores.Workgroup, error) { return stores.Workgroup{}, nil }}
 		w := doRequest(newTestAPI(ms), http.MethodPut, path, nil)
 		checkStatus(t, w, http.StatusNotFound)
@@ -1042,9 +1104,9 @@ func TestConnect(t *testing.T) {
 		}
 	})
 
-	t.Run("DELETE invalid workgroup UUID returns 400", func(t *testing.T) {
-		w := doRequest(newTestAPI(&mockStore{}), http.MethodDelete, "/connect/bad-uuid/myshare", nil)
-		checkStatus(t, w, http.StatusBadRequest)
+	t.Run("DELETE unknown workgroup returns 404", func(t *testing.T) {
+		w := doRequest(newTestAPI(&mockStore{}), http.MethodDelete, "/connect/unknown-name/myshare", nil)
+		checkStatus(t, w, http.StatusNotFound)
 	})
 
 	t.Run("DELETE workgroup not found returns 404", func(t *testing.T) {

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -868,6 +868,57 @@ func TestWorkgroups(t *testing.T) {
 	})
 }
 
+// TestConnectRequest tests POST /connect/:workgroup/:share.
+// The happy path (which calls the real indexd SDK) requires a live indexd server
+// and is therefore not covered here; only the validation paths are tested.
+func TestConnectRequest(t *testing.T) {
+	requestPath := "/connect/" + testUUID.String() + "/myshare"
+
+	t.Run("POST invalid workgroup UUID returns 400", func(t *testing.T) {
+		w := doRequest(newTestAPI(&mockStore{}), http.MethodPost, "/connect/bad-uuid/myshare", nil)
+		checkStatus(t, w, http.StatusBadRequest)
+	})
+
+	t.Run("POST workgroup not found returns 404", func(t *testing.T) {
+		ms := &mockStore{findWorkgroup: func(uuid.UUID) (stores.Workgroup, error) { return stores.Workgroup{}, nil }}
+		w := doRequest(newTestAPI(ms), http.MethodPost, requestPath, nil)
+		checkStatus(t, w, http.StatusNotFound)
+	})
+
+	t.Run("POST workgroup store error returns 500", func(t *testing.T) {
+		ms := &mockStore{findWorkgroup: func(uuid.UUID) (stores.Workgroup, error) { return stores.Workgroup{}, errStore }}
+		w := doRequest(newTestAPI(ms), http.MethodPost, requestPath, nil)
+		checkStatus(t, w, http.StatusInternalServerError)
+	})
+
+	t.Run("POST share not found returns 404", func(t *testing.T) {
+		ms := &mockStore{
+			findWorkgroup: foundWorkgroup(),
+			getShare:      func(string) (stores.Share, error) { return stores.Share{}, nil },
+		}
+		w := doRequest(newTestAPI(ms), http.MethodPost, requestPath, nil)
+		checkStatus(t, w, http.StatusNotFound)
+	})
+
+	t.Run("POST share store error returns 500", func(t *testing.T) {
+		ms := &mockStore{
+			findWorkgroup: foundWorkgroup(),
+			getShare:      func(string) (stores.Share, error) { return stores.Share{}, errStore },
+		}
+		w := doRequest(newTestAPI(ms), http.MethodPost, requestPath, nil)
+		checkStatus(t, w, http.StatusInternalServerError)
+	})
+
+	t.Run("POST renterd share returns 400", func(t *testing.T) {
+		ms := &mockStore{
+			findWorkgroup: foundWorkgroup(),
+			getShare:      foundShare("myshare", "renterd"),
+		}
+		w := doRequest(newTestAPI(ms), http.MethodPost, requestPath, nil)
+		checkStatus(t, w, http.StatusBadRequest)
+	})
+}
+
 func TestConnect(t *testing.T) {
 	path := "/connect/" + testUUID.String() + "/myshare"
 
@@ -888,7 +939,7 @@ func TestConnect(t *testing.T) {
 		}
 	})
 
-	t.Run("PUT connects workgroup to indexd share with app key", func(t *testing.T) {
+	t.Run("PUT reconnects to indexd share with existing app key", func(t *testing.T) {
 		appKey := make([]byte, 64)
 		for i := range appKey {
 			appKey[i] = byte(i)
@@ -904,9 +955,13 @@ func TestConnect(t *testing.T) {
 		}
 		body := map[string]string{"appKey": hex.EncodeToString(appKey)}
 		w := doRequest(newTestAPI(ms), http.MethodPut, path, body)
-		checkStatus(t, w, http.StatusNoContent)
+		checkStatus(t, w, http.StatusOK)
+		resp := decodeJSON[ConnectResponse](t, w)
+		if resp.AppKey != hex.EncodeToString(appKey) {
+			t.Errorf("appKey in response: want %q, got %q", hex.EncodeToString(appKey), resp.AppKey)
+		}
 		if len(gotKey) != 64 {
-			t.Errorf("app key length: want 64, got %d", len(gotKey))
+			t.Errorf("app key length stored: want 64, got %d", len(gotKey))
 		}
 		if gotKey[1] != 1 {
 			t.Errorf("app key[1]: want 1, got %d", gotKey[1])
@@ -951,6 +1006,15 @@ func TestConnect(t *testing.T) {
 		req.Header.Set("Content-Type", "application/json")
 		w := httptest.NewRecorder()
 		newTestAPI(ms).ServeHTTP(w, req)
+		checkStatus(t, w, http.StatusBadRequest)
+	})
+
+	t.Run("PUT indexd share without pending builder returns 400", func(t *testing.T) {
+		ms := &mockStore{
+			findWorkgroup: foundWorkgroup(),
+			getShare:      foundShare("myshare", "indexd"),
+		}
+		w := doRequest(newTestAPI(ms), http.MethodPut, path, nil)
 		checkStatus(t, w, http.StatusBadRequest)
 	})
 

--- a/client/indexd_client_test.go
+++ b/client/indexd_client_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/mike76-dev/sombrero/stores"
 	proto "go.sia.tech/core/rhp/v4"
 	"go.sia.tech/core/types"
@@ -144,7 +145,7 @@ func TestIndexdClient_FileLifecycle(t *testing.T) {
 	db := stores.NewTestStore(t, ctx)
 	t.Cleanup(db.Close)
 
-	acc := newTestAccount(t, db, "alice", "secret123", "wrg")
+	acc := newTestAccount(t, db, "alice", "secret123")
 	share := newTestShare(t, db, "testshare")
 	grantFullAccess(t, db, share, acc)
 
@@ -265,25 +266,30 @@ func waitForRead(t *testing.T, ctx context.Context, c Client, acc stores.Account
 	t.Fatalf("timed out waiting for %s to become readable", path)
 }
 
-func newTestAccount(t *testing.T, db *stores.Database, username, password, workgroup string) stores.Account {
+func newTestAccount(t *testing.T, db *stores.Database, username, password string) stores.Account {
 	t.Helper()
+
+	u := uuid.New()
+	if err := db.AddWorkgroup(stores.Workgroup{UUID: u}); err != nil {
+		t.Fatalf("AddWorkgroup: %v", err)
+	}
 
 	acc := stores.Account{
 		Username:  username,
 		Password:  password,
-		Workgroup: workgroup,
+		Workgroup: u.String(),
 	}
 
 	if err := db.AddAccount(acc); err != nil {
 		t.Fatalf("AddAccount: %v", err)
 	}
 
-	got, err := db.FindAccount(username, workgroup)
+	got, err := db.FindAccount(username, u.String())
 	if err != nil {
 		t.Fatalf("FindAccount: %v", err)
 	}
 	if got.ID == 0 {
-		t.Fatalf("FindAccount returned empty account for %s/%s", username, workgroup)
+		t.Fatalf("FindAccount returned empty account for %s/%s", username, u.String())
 	}
 
 	return got
@@ -426,7 +432,7 @@ func TestIndexdClient_RenameDuringMixedUpload(t *testing.T) {
 	db := stores.NewTestStore(t, ctx)
 	t.Cleanup(db.Close)
 
-	acc := newTestAccount(t, db, "alice", "secret123", "wrg")
+	acc := newTestAccount(t, db, "alice", "secret123")
 	share := newTestShare(t, db, "testshare")
 	grantFullAccess(t, db, share, acc)
 
@@ -481,7 +487,7 @@ func TestIndexdClient_DeleteDuringMixedUpload(t *testing.T) {
 	db := stores.NewTestStore(t, ctx)
 	t.Cleanup(db.Close)
 
-	acc := newTestAccount(t, db, "alice", "secret123", "wrg")
+	acc := newTestAccount(t, db, "alice", "secret123")
 	share := newTestShare(t, db, "testshare")
 	grantFullAccess(t, db, share, acc)
 
@@ -536,7 +542,7 @@ func TestIndexdClient_RenameDirectoryDuringMixedUpload(t *testing.T) {
 	db := stores.NewTestStore(t, ctx)
 	t.Cleanup(db.Close)
 
-	acc := newTestAccount(t, db, "alice", "secret123", "wrg")
+	acc := newTestAccount(t, db, "alice", "secret123")
 	share := newTestShare(t, db, "testshare")
 	grantFullAccess(t, db, share, acc)
 
@@ -602,7 +608,7 @@ func TestIndexdClient_OverwriteFileDuringMixedUpload(t *testing.T) {
 	db := stores.NewTestStore(t, ctx)
 	t.Cleanup(db.Close)
 
-	acc := newTestAccount(t, db, "alice", "secret123", "wrg")
+	acc := newTestAccount(t, db, "alice", "secret123")
 	share := newTestShare(t, db, "testshare")
 	grantFullAccess(t, db, share, acc)
 

--- a/client/indexd_client_test.go
+++ b/client/indexd_client_test.go
@@ -327,15 +327,26 @@ func newTestShare(t *testing.T, db *stores.Database, name string) stores.Share {
 func grantFullAccess(t *testing.T, db *stores.Database, sh stores.Share, acc stores.Account) {
 	t.Helper()
 
-	err := db.SetAccessRights(stores.AccessRights{
+	wgUUID, err := uuid.Parse(acc.Workgroup)
+	if err != nil {
+		t.Fatalf("parse workgroup UUID: %v", err)
+	}
+	wg, err := db.FindWorkgroup(wgUUID)
+	if err != nil {
+		t.Fatalf("FindWorkgroup: %v", err)
+	}
+	// AddConnection is idempotent; safe to call once per (workgroup, share) pair.
+	if err := db.AddConnection(wg, sh, make(types.PrivateKey, 64)); err != nil {
+		t.Fatalf("AddConnection: %v", err)
+	}
+	if err := db.SetAccessRights(stores.AccessRights{
 		ShareName:     sh.Name,
 		AccountID:     acc.ID,
 		ReadAccess:    true,
 		WriteAccess:   true,
 		DeleteAccess:  true,
 		ExecuteAccess: true,
-	})
-	if err != nil {
+	}); err != nil {
 		t.Fatalf("SetAccessRights: %v", err)
 	}
 }

--- a/client/indexd_client_test.go
+++ b/client/indexd_client_test.go
@@ -692,3 +692,215 @@ func mustNotReadEquals(t *testing.T, ctx context.Context, c Client, acc stores.A
 		t.Fatalf("Read(%s) unexpectedly matched old content", path)
 	}
 }
+
+func newTestWorkgroup(t *testing.T, db *stores.Database) stores.Workgroup {
+	t.Helper()
+
+	u := uuid.New()
+	if err := db.AddWorkgroup(stores.Workgroup{UUID: u}); err != nil {
+		t.Fatalf("AddWorkgroup: %v", err)
+	}
+	got, err := db.FindWorkgroup(u)
+	if err != nil {
+		t.Fatalf("FindWorkgroup: %v", err)
+	}
+	if got.ID == 0 {
+		t.Fatalf("FindWorkgroup returned empty workgroup for %s", u)
+	}
+	return got
+}
+
+func newTestAccountInWorkgroup(t *testing.T, db *stores.Database, username, password string, wg stores.Workgroup) stores.Account {
+	t.Helper()
+
+	acc := stores.Account{
+		Username:  username,
+		Password:  password,
+		Workgroup: wg.UUID.String(),
+	}
+	if err := db.AddAccount(acc); err != nil {
+		t.Fatalf("AddAccount(%s): %v", username, err)
+	}
+	got, err := db.FindAccount(username, wg.UUID.String())
+	if err != nil {
+		t.Fatalf("FindAccount(%s): %v", username, err)
+	}
+	if got.ID == 0 {
+		t.Fatalf("FindAccount returned empty account for %s", username)
+	}
+	return got
+}
+
+func mustNotFound(t *testing.T, ctx context.Context, c Client, acc stores.Account, path string, size int) {
+	t.Helper()
+
+	var buf bytes.Buffer
+	err := c.Read(ctx, acc, path, 0, uint64(size), &buf)
+	if !errors.Is(err, stores.ErrNotFound) {
+		t.Errorf("Read(%s) as %s: expected ErrNotFound, got %v", path, acc.Username, err)
+	}
+}
+
+// TestIndexdClient_CrossWorkgroupIsolation verifies that files uploaded by an
+// account in one workgroup are never visible to an account in a different
+// workgroup, even when both are connected to the same share.
+func TestIndexdClient_CrossWorkgroupIsolation(t *testing.T) {
+	ctx := context.Background()
+
+	db := stores.NewTestStore(t, ctx)
+	t.Cleanup(db.Close)
+
+	wg1 := newTestWorkgroup(t, db)
+	wg2 := newTestWorkgroup(t, db)
+	alice := newTestAccountInWorkgroup(t, db, "alice", "secret", wg1)
+	bob := newTestAccountInWorkgroup(t, db, "bob", "secret", wg2)
+
+	share := newTestShare(t, db, "testshare")
+	grantFullAccess(t, db, share, alice)
+	grantFullAccess(t, db, share, bob)
+
+	c := newIndexdClient(db, newFakeBackend(), share.Name, 1, 0)
+	t.Cleanup(func() { _ = c.Close() })
+
+	content := []byte("alice's secret data")
+	path := "secret.txt"
+
+	uploadID, err := c.StartUpload(ctx, alice, path)
+	if err != nil {
+		t.Fatalf("StartUpload: %v", err)
+	}
+	if _, err := c.Write(ctx, bytes.NewReader(content), path, uploadID, 1, 0, uint64(len(content))); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+	if err := c.FinishUpload(ctx, path, uploadID, nil); err != nil {
+		t.Fatalf("FinishUpload: %v", err)
+	}
+	waitForRead(t, ctx, c, alice, path, content)
+
+	mustReadEquals(t, ctx, c, alice, path, content)
+	mustNotFound(t, ctx, c, bob, path, len(content))
+}
+
+// TestIndexdClient_WithinWorkgroupPrivacy verifies that files in private
+// directories (the default) are invisible to other accounts in the same
+// workgroup, and that root-level files are always private.
+func TestIndexdClient_WithinWorkgroupPrivacy(t *testing.T) {
+	ctx := context.Background()
+
+	db := stores.NewTestStore(t, ctx)
+	t.Cleanup(db.Close)
+
+	wg := newTestWorkgroup(t, db)
+	alice := newTestAccountInWorkgroup(t, db, "alice", "secret", wg)
+	bob := newTestAccountInWorkgroup(t, db, "bob", "secret", wg)
+
+	share := newTestShare(t, db, "testshare")
+	grantFullAccess(t, db, share, alice)
+	grantFullAccess(t, db, share, bob)
+
+	c := newIndexdClient(db, newFakeBackend(), share.Name, 1, 0)
+	t.Cleanup(func() { _ = c.Close() })
+
+	content := []byte("alice's private content")
+
+	// Upload to root (directory_id = NULL, always private).
+	rootPath := "root.txt"
+	uploadID, err := c.StartUpload(ctx, alice, rootPath)
+	if err != nil {
+		t.Fatalf("StartUpload(root): %v", err)
+	}
+	if _, err := c.Write(ctx, bytes.NewReader(content), rootPath, uploadID, 1, 0, uint64(len(content))); err != nil {
+		t.Fatalf("Write(root): %v", err)
+	}
+	if err := c.FinishUpload(ctx, rootPath, uploadID, nil); err != nil {
+		t.Fatalf("FinishUpload(root): %v", err)
+	}
+	waitForRead(t, ctx, c, alice, rootPath, content)
+
+	// Upload to a private directory (MakeDirectory always sets private=true).
+	if err := c.MakeDirectory(ctx, alice, "private-dir"); err != nil {
+		t.Fatalf("MakeDirectory: %v", err)
+	}
+	dirPath := "private-dir/file.txt"
+	uploadID, err = c.StartUpload(ctx, alice, dirPath)
+	if err != nil {
+		t.Fatalf("StartUpload(dir): %v", err)
+	}
+	if _, err := c.Write(ctx, bytes.NewReader(content), dirPath, uploadID, 1, 0, uint64(len(content))); err != nil {
+		t.Fatalf("Write(dir): %v", err)
+	}
+	if err := c.FinishUpload(ctx, dirPath, uploadID, nil); err != nil {
+		t.Fatalf("FinishUpload(dir): %v", err)
+	}
+	waitForRead(t, ctx, c, alice, dirPath, content)
+
+	mustReadEquals(t, ctx, c, alice, rootPath, content)
+	mustReadEquals(t, ctx, c, alice, dirPath, content)
+
+	mustNotFound(t, ctx, c, bob, rootPath, len(content))
+	mustNotFound(t, ctx, c, bob, dirPath, len(content))
+}
+
+// TestIndexdClient_WithinWorkgroupPublicDirectory verifies that files in a
+// public directory (private=false) are visible to all accounts in the same
+// workgroup, while a private directory in the same workgroup remains hidden.
+func TestIndexdClient_WithinWorkgroupPublicDirectory(t *testing.T) {
+	ctx := context.Background()
+
+	db := stores.NewTestStore(t, ctx)
+	t.Cleanup(db.Close)
+
+	wg := newTestWorkgroup(t, db)
+	alice := newTestAccountInWorkgroup(t, db, "alice", "secret", wg)
+	bob := newTestAccountInWorkgroup(t, db, "bob", "secret", wg)
+
+	share := newTestShare(t, db, "testshare")
+	grantFullAccess(t, db, share, alice)
+	grantFullAccess(t, db, share, bob)
+
+	c := newIndexdClient(db, newFakeBackend(), share.Name, 1, 0)
+	t.Cleanup(func() { _ = c.Close() })
+
+	// Create a public directory directly via the store (the client always creates private dirs).
+	if err := db.CreateDirectory(alice, share.Name, "/shared", false); err != nil {
+		t.Fatalf("CreateDirectory(public): %v", err)
+	}
+
+	content := []byte("shared content")
+	sharedPath := "shared/file.txt"
+
+	uploadID, err := c.StartUpload(ctx, alice, sharedPath)
+	if err != nil {
+		t.Fatalf("StartUpload(shared): %v", err)
+	}
+	if _, err := c.Write(ctx, bytes.NewReader(content), sharedPath, uploadID, 1, 0, uint64(len(content))); err != nil {
+		t.Fatalf("Write(shared): %v", err)
+	}
+	if err := c.FinishUpload(ctx, sharedPath, uploadID, nil); err != nil {
+		t.Fatalf("FinishUpload(shared): %v", err)
+	}
+	waitForRead(t, ctx, c, alice, sharedPath, content)
+
+	mustReadEquals(t, ctx, c, alice, sharedPath, content)
+	mustReadEquals(t, ctx, c, bob, sharedPath, content)
+
+	// Verify a private directory in the same workgroup still hides its files from bob.
+	if err := c.MakeDirectory(ctx, alice, "private-dir"); err != nil {
+		t.Fatalf("MakeDirectory(private): %v", err)
+	}
+	privatePath := "private-dir/secret.txt"
+	uploadID, err = c.StartUpload(ctx, alice, privatePath)
+	if err != nil {
+		t.Fatalf("StartUpload(private): %v", err)
+	}
+	if _, err := c.Write(ctx, bytes.NewReader(content), privatePath, uploadID, 1, 0, uint64(len(content))); err != nil {
+		t.Fatalf("Write(private): %v", err)
+	}
+	if err := c.FinishUpload(ctx, privatePath, uploadID, nil); err != nil {
+		t.Fatalf("FinishUpload(private): %v", err)
+	}
+	waitForRead(t, ctx, c, alice, privatePath, content)
+
+	mustReadEquals(t, ctx, c, alice, privatePath, content)
+	mustNotFound(t, ctx, c, bob, privatePath, len(content))
+}

--- a/client/main_test.go
+++ b/client/main_test.go
@@ -1,0 +1,24 @@
+package client
+
+import (
+	"os"
+	"syscall"
+	"testing"
+)
+
+// TestMain serializes this package's DB access against other test packages
+// that share the same sombrero_test PostgreSQL database.
+func TestMain(m *testing.M) {
+	f, err := os.OpenFile("/tmp/sombrero_test.lock", os.O_CREATE|os.O_RDWR, 0600)
+	if err != nil {
+		panic(err)
+	}
+	if err := syscall.Flock(int(f.Fd()), syscall.LOCK_EX); err != nil {
+		f.Close()
+		panic(err)
+	}
+	code := m.Run()
+	syscall.Flock(int(f.Fd()), syscall.LOCK_UN) //nolint
+	f.Close()
+	os.Exit(code)
+}

--- a/compress/lz77/lz77_test.go
+++ b/compress/lz77/lz77_test.go
@@ -2,17 +2,16 @@ package lz77
 
 import (
 	"bytes"
-	"crypto/rand"
-	"math/big"
 	"testing"
+
+	"lukechampine.com/frand"
 )
 
 var buf []byte
 var out []byte
 
 func TestCompress(t *testing.T) {
-	sb, _ := rand.Int(rand.Reader, big.NewInt(2<<30))
-	size := int(sb.Int64()) + 1
+	size := frand.Intn(2<<30) + 1
 	buf = make([]byte, size)
 	i := 0
 	for i < size {
@@ -20,9 +19,8 @@ func TestCompress(t *testing.T) {
 		if i+m > size {
 			m = size - i
 		}
-		cb, _ := rand.Int(rand.Reader, big.NewInt(int64(m)))
-		c := int(cb.Int64() + 1)
-		rand.Read(buf[i : i+c])
+		c := frand.Intn(m) + 1
+		frand.Read(buf[i : i+c])
 		i += c
 
 		m = 10000
@@ -32,8 +30,7 @@ func TestCompress(t *testing.T) {
 		if m == 0 {
 			break
 		}
-		cb, _ = rand.Int(rand.Reader, big.NewInt(int64(m)))
-		c = int(cb.Int64() + 1)
+		c = frand.Intn(m) + 1
 		for j := 0; j < c; j++ {
 			buf[i+j] = 0xff
 		}

--- a/compress/lznt1/lznt1_test.go
+++ b/compress/lznt1/lznt1_test.go
@@ -2,17 +2,16 @@ package lznt1
 
 import (
 	"bytes"
-	"crypto/rand"
-	"math/big"
 	"testing"
+
+	"lukechampine.com/frand"
 )
 
 var buf []byte
 var out []byte
 
 func TestCompress(t *testing.T) {
-	sb, _ := rand.Int(rand.Reader, big.NewInt(2<<30))
-	size := int(sb.Int64()) + 1
+	size := frand.Intn(2<<30) + 1
 	buf = make([]byte, size)
 	i := 0
 	for i < size {
@@ -20,9 +19,8 @@ func TestCompress(t *testing.T) {
 		if i+m > size {
 			m = size - i
 		}
-		cb, _ := rand.Int(rand.Reader, big.NewInt(int64(m)))
-		c := int(cb.Int64() + 1)
-		rand.Read(buf[i : i+c])
+		c := frand.Intn(m) + 1
+		frand.Read(buf[i : i+c])
 		i += c
 
 		m = 10000
@@ -32,8 +30,7 @@ func TestCompress(t *testing.T) {
 		if m == 0 {
 			break
 		}
-		cb, _ = rand.Int(rand.Reader, big.NewInt(int64(m)))
-		c = int(cb.Int64() + 1)
+		c = frand.Intn(m) + 1
 		for j := 0; j < c; j++ {
 			buf[i+j] = 0xff
 		}

--- a/conn.go
+++ b/conn.go
@@ -791,7 +791,7 @@ func (c *connection) processRequest(req *smb2.Request) (smb2.GenericResponse, *s
 				return resp, ss, nil
 			}
 
-			info, err = tc.share.client.Object(ctx, acc, path)
+			info, err = tc.client.Object(ctx, acc, path)
 			if err != nil && errors.Is(err, context.DeadlineExceeded) {
 				cancel()
 				resp := smb2.NewErrorResponse(cr, smb2.STATUS_IO_TIMEOUT, 0, nil)
@@ -842,7 +842,7 @@ func (c *connection) processRequest(req *smb2.Request) (smb2.GenericResponse, *s
 					result = smb2.FILE_CREATED
 					if cr.CreateOptions()&smb2.FILE_DIRECTORY_FILE > 0 { // Make a new directory
 						info.Key += "/"
-						if err := tc.share.client.MakeDirectory(ctx, acc, path); err != nil {
+						if err := tc.client.MakeDirectory(ctx, acc, path); err != nil {
 							cancel()
 							if errors.Is(err, stores.ErrDirectoryExists) {
 								resp := smb2.NewErrorResponse(cr, smb2.STATUS_OBJECT_NAME_COLLISION, 0, nil)
@@ -873,7 +873,7 @@ func (c *connection) processRequest(req *smb2.Request) (smb2.GenericResponse, *s
 						result = smb2.FILE_CREATED
 						if cr.CreateOptions()&smb2.FILE_DIRECTORY_FILE > 0 { // Make a new directory
 							info.Key += "/"
-							if err := tc.share.client.MakeDirectory(ctx, acc, path); err != nil {
+							if err := tc.client.MakeDirectory(ctx, acc, path); err != nil {
 								cancel()
 								if errors.Is(err, stores.ErrDirectoryExists) {
 									resp := smb2.NewErrorResponse(cr, smb2.STATUS_OBJECT_NAME_COLLISION, 0, nil)
@@ -920,7 +920,7 @@ func (c *connection) processRequest(req *smb2.Request) (smb2.GenericResponse, *s
 						result = smb2.FILE_CREATED
 						if cr.CreateOptions()&smb2.FILE_DIRECTORY_FILE > 0 { // Make a new directory
 							info.Key += "/"
-							if err := tc.share.client.MakeDirectory(ctx, acc, path); err != nil {
+							if err := tc.client.MakeDirectory(ctx, acc, path); err != nil {
 								cancel()
 								if errors.Is(err, stores.ErrDirectoryExists) {
 									resp := smb2.NewErrorResponse(cr, smb2.STATUS_OBJECT_NAME_COLLISION, 0, nil)
@@ -979,7 +979,7 @@ func (c *connection) processRequest(req *smb2.Request) (smb2.GenericResponse, *s
 			case smb2.CREATE_QUERY_MAXIMAL_ACCESS_REQUEST:
 				respContexts[id] = smb2.HandleCreateQueryMaximalAccessRequest(ctx, op.lastModified, op.grantedAccess)
 			case smb2.CREATE_QUERY_ON_DISK_ID:
-				respContexts[id] = smb2.HandleCreateQueryOnDiskID(op.handle, tc.share.volumeID)
+				respContexts[id] = smb2.HandleCreateQueryOnDiskID(op.handle, tc.volumeID)
 			case smb2.CREATE_ALLOCATION_SIZE: // The file is about to be uploaded, we just got its size
 				op.mu.Lock()
 				op.allocated = binary.LittleEndian.Uint64(ctx)
@@ -1072,7 +1072,7 @@ func (c *connection) processRequest(req *smb2.Request) (smb2.GenericResponse, *s
 			tc.mu.Lock()
 			delete(tc.persistedOpens, path)
 			tc.mu.Unlock()
-			if err := tc.share.client.Delete(op.ctx, acc, path, attr&smb2.FILE_ATTRIBUTE_DIRECTORY > 0); err != nil {
+			if err := tc.client.Delete(op.ctx, acc, path, attr&smb2.FILE_ATTRIBUTE_DIRECTORY > 0); err != nil {
 				log.Printf("Error deleting object %s: %v", path, err)
 			}
 		}
@@ -1886,7 +1886,7 @@ func (c *connection) processRequest(req *smb2.Request) (smb2.GenericResponse, *s
 				return resp, ss, nil
 			}
 
-			dir, parentDir, err := tc.share.client.Parents(op.ctx, acc, searchPath)
+			dir, parentDir, err := tc.client.Parents(op.ctx, acc, searchPath)
 			if err != nil {
 				log.Printf("Error getting parent directories of path %s: %v", searchPath, err)
 				resp := smb2.NewErrorResponse(qdr, smb2.STATUS_BAD_NETWORK_NAME, 0, nil)
@@ -2069,11 +2069,11 @@ func (c *connection) processRequest(req *smb2.Request) (smb2.GenericResponse, *s
 		case smb2.INFO_FILESYSTEM:
 			switch qir.FileInfoClass() {
 			case smb2.FileFsVolumeInformation:
-				info = smb2.FileFsVolumeInfo(tc.share.createdAt, tc.share.serialNo(), tc.share.name)
+				info = smb2.FileFsVolumeInfo(tc.createdAt, uint32(tc.volumeID), tc.share.name)
 			case smb2.FileFsAttributeInformation:
 				info = smb2.FileFsAttributeInfo(tc.share.backend)
 			case smb2.FileFsSizeInformation:
-				si, err := tc.share.client.Storage(op.ctx)
+				si, err := tc.client.Storage(op.ctx)
 				if err != nil {
 					log.Println("Error getting storage info:", err)
 				} else {
@@ -2081,7 +2081,7 @@ func (c *connection) processRequest(req *smb2.Request) (smb2.GenericResponse, *s
 				}
 			case smb2.FileFsFullSizeInformation:
 				// Same as above.
-				si, err := tc.share.client.Storage(op.ctx)
+				si, err := tc.client.Storage(op.ctx)
 				if err != nil {
 					log.Println("Error getting storage info:", err)
 				} else {
@@ -2090,7 +2090,7 @@ func (c *connection) processRequest(req *smb2.Request) (smb2.GenericResponse, *s
 			case smb2.FileFsDeviceInformation:
 				info = smb2.FileFsDeviceInfo()
 			case smb2.FileFsObjectIdInformation:
-				info = smb2.FileFsObjectIDInfo(tc.share.volumeID)
+				info = smb2.FileFsObjectIDInfo(tc.volumeID)
 			default: // Other classes are not supported yet
 				resp := smb2.NewErrorResponse(qir, smb2.STATUS_NOT_SUPPORTED, 0, nil)
 				return resp, ss, nil
@@ -2242,7 +2242,7 @@ func (c *connection) processRequest(req *smb2.Request) (smb2.GenericResponse, *s
 
 				if sir.Buffer()[0] == 1 { // Set the delete flag
 					if attr&smb2.FILE_ATTRIBUTE_DIRECTORY != 0 {
-						empty, err := tc.share.client.IsEmpty(op.ctx, acc, path+"/")
+						empty, err := tc.client.IsEmpty(op.ctx, acc, path+"/")
 						if err != nil {
 							log.Printf("Error listing directory contents on %s: %v", path, err)
 							resp := smb2.NewErrorResponse(sir, smb2.STATUS_NETWORK_NAME_DELETED, 0, nil)
@@ -2305,7 +2305,7 @@ func (c *connection) processRequest(req *smb2.Request) (smb2.GenericResponse, *s
 					op.mu.Unlock()
 					tc.mu.Unlock()
 				} else {
-					if err := tc.share.client.Rename(
+					if err := tc.client.Rename(
 						op.ctx,
 						acc,
 						path,

--- a/conn.go
+++ b/conn.go
@@ -3,7 +3,6 @@ package main
 import (
 	"bytes"
 	"context"
-	"crypto/rand"
 	"crypto/sha512"
 	"encoding/binary"
 	"errors"
@@ -23,6 +22,7 @@ import (
 	"github.com/mike76-dev/sombrero/utils"
 	"github.com/oiweiwei/go-msrpc/msrpc/lsat/lsarpc/v0"
 	"github.com/oiweiwei/go-msrpc/ndr"
+	"lukechampine.com/frand"
 )
 
 const (
@@ -114,7 +114,7 @@ func (c *connection) acceptRequest(msg []byte) error {
 
 	// Assign a random cancel ID.
 	cid := make([]byte, 8)
-	rand.Read(cid)
+	frand.Read(cid)
 
 	// Check for encryption.
 	var tsid uint64
@@ -410,7 +410,7 @@ func (c *connection) processRequest(req *smb2.Request) (smb2.GenericResponse, *s
 
 			var blobs [][]byte
 			var salt [32]byte
-			rand.Read(salt[:])
+			frand.Read(salt[:])
 			blobs = append(blobs, smb2.PreauthIntegrityCapabilities(salt[:]))
 
 			if ciphers != nil {
@@ -1248,7 +1248,7 @@ func (c *connection) processRequest(req *smb2.Request) (smb2.GenericResponse, *s
 		// to drop the connection. We send an interim response and process the request asynchronously
 		// to prevent that.
 		aid := make([]byte, 8)
-		rand.Read(aid)
+		frand.Read(aid)
 		asyncID := binary.LittleEndian.Uint64(aid)
 		c.mu.Lock()
 		c.asyncCommandList[asyncID] = req
@@ -1388,7 +1388,7 @@ func (c *connection) processRequest(req *smb2.Request) (smb2.GenericResponse, *s
 		// to drop the connection. We send an interim response and process the request asynchronously
 		// to prevent that.
 		aid := make([]byte, 8)
-		rand.Read(aid)
+		frand.Read(aid)
 		asyncID := binary.LittleEndian.Uint64(aid)
 		c.mu.Lock()
 		c.asyncCommandList[asyncID] = req
@@ -1965,7 +1965,7 @@ func (c *connection) processRequest(req *smb2.Request) (smb2.GenericResponse, *s
 
 		// Put the request in the async command list.
 		aid := make([]byte, 8)
-		rand.Read(aid)
+		frand.Read(aid)
 		asyncID := binary.LittleEndian.Uint64(aid)
 		req.Header().SetAsyncID(asyncID)
 		req.Header().SetFlag(smb2.FLAGS_ASYNC_COMMAND)

--- a/init.sql
+++ b/init.sql
@@ -13,6 +13,7 @@ CREATE TABLE shares (
 CREATE TABLE workgroups (
     id SERIAL PRIMARY KEY,
     uuid BYTEA NOT NULL,
+    name TEXT UNIQUE,
     created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
     CONSTRAINT workgroups_uuid_length CHECK (octet_length(uuid) = 16),
     CONSTRAINT workgroups_unique UNIQUE (uuid)

--- a/init.sql
+++ b/init.sql
@@ -42,11 +42,13 @@ CREATE INDEX idx_connections_share ON connections (share_name);
 CREATE TABLE policies (
     share_name TEXT NOT NULL,
     account INT NOT NULL REFERENCES accounts(id) ON DELETE CASCADE,
+    workgroup INT NOT NULL,
     read_access BOOLEAN NOT NULL,
     write_access BOOLEAN NOT NULL,
     delete_access BOOLEAN NOT NULL,
     execute_access BOOLEAN NOT NULL,
     CONSTRAINT policies_share_fk FOREIGN KEY (share_name) REFERENCES shares(share_name) ON DELETE CASCADE,
+    CONSTRAINT policies_connection_fk FOREIGN KEY (workgroup, share_name) REFERENCES connections(workgroup, share_name) ON DELETE CASCADE,
     CONSTRAINT share_account UNIQUE (share_name, account)
 );
 CREATE INDEX idx_policies_account ON policies (account);

--- a/init.sql
+++ b/init.sql
@@ -7,17 +7,36 @@ CREATE TABLE shares (
     remark TEXT NOT NULL DEFAULT '',
     created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
     data_shards INT NOT NULL DEFAULT 0,
-    parity_shards INT NOT NULL DEFAULT 0,
-    app_key BYTEA
+    parity_shards INT NOT NULL DEFAULT 0
+);
+
+CREATE TABLE workgroups (
+    id SERIAL PRIMARY KEY,
+    uuid BYTEA NOT NULL,
+    created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+    CONSTRAINT workgroups_uuid_length CHECK (octet_length(uuid) = 16),
+    CONSTRAINT workgroups_unique UNIQUE (uuid)
 );
 
 CREATE TABLE accounts (
     id SERIAL PRIMARY KEY,
     account_name TEXT NOT NULL,
     password_hash BYTEA NOT NULL,
-    workgroup TEXT NOT NULL,
-    CONSTRAINT accounts_password_hash_length CHECK (octet_length(password_hash) = 16)
+    workgroup INT NOT NULL REFERENCES workgroups(id) ON DELETE CASCADE,
+    created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+    CONSTRAINT accounts_password_hash_length CHECK (octet_length(password_hash) = 16),
+    CONSTRAINT accounts_unique UNIQUE (account_name, workgroup)
 );
+
+CREATE TABLE connections (
+    workgroup INT NOT NULL REFERENCES workgroups(id) ON DELETE CASCADE,
+    share_name TEXT NOT NULL REFERENCES shares(share_name) ON DELETE CASCADE,
+    app_key BYTEA,
+    CONSTRAINT connections_unique UNIQUE (workgroup, share_name),
+    CONSTRAINT connections_app_key_length CHECK (app_key IS NULL OR octet_length(app_key) = 64)
+);
+CREATE INDEX idx_connections_workgroup ON connections (workgroup);
+CREATE INDEX idx_connections_share ON connections (share_name);
 
 CREATE TABLE policies (
     share_name TEXT NOT NULL,
@@ -43,15 +62,16 @@ CREATE TABLE directories (
     name TEXT NOT NULL,
     full_path TEXT NOT NULL,
     account INT NOT NULL REFERENCES accounts(id) ON DELETE CASCADE,
+    workgroup INT NOT NULL REFERENCES workgroups(id) ON DELETE CASCADE,
     private BOOLEAN NOT NULL DEFAULT TRUE,
     created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
     modified_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
     PRIMARY KEY (share_name, id),
-    CONSTRAINT directories_id_unique UNIQUE (id),
-    CONSTRAINT directories_share_fk FOREIGN KEY (share_name) REFERENCES shares(share_name) ON DELETE CASCADE,
-    CONSTRAINT directories_parent_fk FOREIGN KEY (share_name, parent_id) REFERENCES directories(share_name, id) ON DELETE CASCADE,
-    CONSTRAINT directories_unique_path UNIQUE (share_name, full_path),
-    CONSTRAINT directories_unique_entry UNIQUE (share_name, parent_id, name)
+    UNIQUE (id),
+    FOREIGN KEY (share_name) REFERENCES shares(share_name) ON DELETE CASCADE,
+    FOREIGN KEY (share_name, parent_id) REFERENCES directories(share_name, id) ON DELETE CASCADE,
+    UNIQUE (share_name, full_path),
+    UNIQUE (share_name, parent_id, name)
 );
 
 CREATE TABLE objects (
@@ -62,11 +82,12 @@ CREATE TABLE objects (
     full_path TEXT NOT NULL,
     size BIGINT NOT NULL DEFAULT 0,
     account INT NOT NULL REFERENCES accounts(id) ON DELETE CASCADE,
+    workgroup INT NOT NULL REFERENCES workgroups(id) ON DELETE CASCADE,
     created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
     modified_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
     temporary BOOLEAN NOT NULL DEFAULT FALSE,
-    CONSTRAINT objects_share_fk FOREIGN KEY (share_name) REFERENCES shares(share_name) ON DELETE CASCADE,
-    CONSTRAINT objects_directory_fk FOREIGN KEY (share_name, directory_id) REFERENCES directories(share_name, id) ON DELETE CASCADE
+    FOREIGN KEY (share_name) REFERENCES shares(share_name) ON DELETE CASCADE,
+    FOREIGN KEY (share_name, directory_id) REFERENCES directories(share_name, id) ON DELETE CASCADE
 );
 
 CREATE INDEX idx_directories_lookup_path ON directories (share_name, full_path);

--- a/main.go
+++ b/main.go
@@ -146,7 +146,12 @@ func main() {
 		}
 
 		for _, share := range shares {
-			share.client.Close()
+			if share.client != nil { // renterd share
+				share.client.Close()
+			}
+			for _, conn := range share.indexdConns { // indexd share
+				conn.client.Close()
+			}
 		}
 
 		apiSrv.Close()

--- a/ntlm/server.go
+++ b/ntlm/server.go
@@ -5,7 +5,7 @@ import (
 	"bytes"
 	"crypto/hmac"
 	"crypto/md5"
-	"crypto/rand"
+
 	"crypto/rc4"
 	"encoding/asn1"
 	"encoding/binary"
@@ -16,6 +16,7 @@ import (
 	"github.com/mike76-dev/sombrero/spnego"
 	"github.com/mike76-dev/sombrero/stores"
 	"github.com/mike76-dev/sombrero/utils"
+	"lukechampine.com/frand"
 )
 
 // Server is an NTLMv2 authentication server.
@@ -167,10 +168,7 @@ func (s *Server) Challenge(nmsg []byte) (cmsg []byte, err error) {
 		binary.LittleEndian.PutUint32(cmsg[44:48], uint32(off))
 	}
 
-	_, err = rand.Read(cmsg[24:32])
-	if err != nil {
-		return nil, err
-	}
+	frand.Read(cmsg[24:32])
 
 	if flags&NTLMSSP_NEGOTIATE_VERSION != 0 {
 		copy(cmsg[48:56], version)

--- a/open.go
+++ b/open.go
@@ -3,7 +3,6 @@ package main
 import (
 	"bytes"
 	"context"
-	"crypto/rand"
 	"encoding/binary"
 	"errors"
 	"log"
@@ -22,6 +21,7 @@ import (
 	"github.com/oiweiwei/go-msrpc/msrpc/lsat/lsarpc/v0"
 	"go.sia.tech/renterd/v2/api"
 	"golang.org/x/crypto/blake2b"
+	"lukechampine.com/frand"
 )
 
 var (
@@ -164,7 +164,7 @@ func (ss *session) registerOpen(cr smb2.CreateRequest, tc *treeConnect, info cli
 	}
 
 	fid := make([]byte, 16)
-	rand.Read(fid)
+	frand.Read(fid)
 	op := &open{
 		handle:         binary.LittleEndian.Uint64(id[:8]),
 		fileID:         binary.LittleEndian.Uint64(fid[:8]),
@@ -439,7 +439,7 @@ func (op *open) newLSAFrame(ctx ntlm.SecurityContext) *rpc.Frame {
 	defer op.mu.Unlock()
 
 	id := make([]byte, 16)
-	rand.Read(id)
+	frand.Read(id)
 	guid, _ := dtyp.GUIDFromBytes(id)
 	frame := &rpc.Frame{
 		Handle: lsarpc.Handle{

--- a/open.go
+++ b/open.go
@@ -252,8 +252,7 @@ func (op *open) queryDirectory(acc stores.Account, pattern string) error {
 		return errNoDirectory
 	}
 
-	share := op.treeConnect.share
-	ois, err := share.client.List(op.ctx, acc, op.pathName+"/")
+	ois, err := op.treeConnect.client.List(op.ctx, acc, op.pathName+"/")
 	if err != nil {
 		return err
 	}
@@ -456,7 +455,7 @@ func (op *open) newLSAFrame(ctx ntlm.SecurityContext) *rpc.Frame {
 // checkForChanges monitors if any significant changes have occurred in the specified directory.
 // Significant changes include: file names, sizes, modify times, or contents.
 func (op *open) checkForChanges(req smb2.ChangeNotifyRequest, acc stores.Account, stopChan chan struct{}) {
-	ois, err := op.treeConnect.share.client.List(op.ctx, acc, op.pathName)
+	ois, err := op.treeConnect.client.List(op.ctx, acc, op.pathName)
 	if err != nil {
 		return
 	}
@@ -494,7 +493,7 @@ func (op *open) checkForChanges(req smb2.ChangeNotifyRequest, acc stores.Account
 		case <-time.After(15 * time.Second): // Check every 15 seconds
 		}
 
-		ois, err := op.treeConnect.share.client.List(op.ctx, acc, op.pathName)
+		ois, err := op.treeConnect.client.List(op.ctx, acc, op.pathName)
 		if err != nil {
 			continue
 		}
@@ -571,7 +570,7 @@ func (op *open) getResumeKey() []byte {
 func (op *open) getObjectID() []byte {
 	id := make([]byte, 64)
 	copy(id[:16], op.resumeKey[:16])
-	binary.LittleEndian.PutUint64(id[16:24], op.treeConnect.share.volumeID)
+	binary.LittleEndian.PutUint64(id[16:24], op.treeConnect.volumeID)
 	copy(id[32:48], op.resumeKey[:16])
 	return id
 }
@@ -589,7 +588,7 @@ func (op *open) read(offset, length uint64) []byte {
 
 	readData := func(acc stores.Account, o, l uint64) ([]byte, error) {
 		var buf bytes.Buffer
-		err := op.treeConnect.share.client.Read(op.ctx, acc, path, o, l, &buf)
+		err := op.treeConnect.client.Read(op.ctx, acc, path, o, l, &buf)
 		if err != nil {
 			return nil, err
 		}
@@ -671,7 +670,7 @@ func (op *open) startUpload() error {
 		return err
 	}
 
-	id, err := op.treeConnect.share.client.StartUpload(op.ctx, acc, op.pathName)
+	id, err := op.treeConnect.client.StartUpload(op.ctx, acc, op.pathName)
 	if err != nil {
 		return err
 	}
@@ -681,7 +680,7 @@ func (op *open) startUpload() error {
 		pending:    make(map[uint64]*uploadChunk),
 		nextOffset: 0,
 		bufOffset:  0,
-		maxLength:  op.treeConnect.share.maxUploadSize,
+		maxLength:  op.treeConnect.maxUploadSize,
 	}
 
 	return nil
@@ -738,7 +737,7 @@ func (op *open) write(offset uint64, data []byte) error {
 		partOffset := u.bufOffset
 
 		u.partCount++
-		eTag, err := op.treeConnect.share.client.Write(
+		eTag, err := op.treeConnect.client.Write(
 			op.ctx,
 			bytes.NewReader(sector),
 			op.pathName,
@@ -802,7 +801,7 @@ func (op *open) flush() error {
 		u.partCount++
 		partOffset := u.bufOffset
 		partSize := uint64(len(u.buf))
-		eTag, err := op.treeConnect.share.client.Write(
+		eTag, err := op.treeConnect.client.Write(
 			op.ctx,
 			bytes.NewReader(u.buf),
 			op.pathName,
@@ -828,7 +827,7 @@ func (op *open) flush() error {
 	finalSize := u.totalSize
 	u.mu.Unlock()
 
-	if err := op.treeConnect.share.client.FinishUpload(op.ctx, op.pathName, uploadID, parts); err != nil {
+	if err := op.treeConnect.client.FinishUpload(op.ctx, op.pathName, uploadID, parts); err != nil {
 		return err
 	}
 
@@ -863,5 +862,5 @@ func (op *open) cancelUpload() {
 	uploadID := u.uploadID
 	u.mu.Unlock()
 
-	_ = op.treeConnect.share.client.AbortUpload(op.ctx, op.pathName, uploadID)
+	_ = op.treeConnect.client.AbortUpload(op.ctx, op.pathName, uploadID)
 }

--- a/rpc/rpc.go
+++ b/rpc/rpc.go
@@ -2,7 +2,6 @@
 package rpc
 
 import (
-	"crypto/rand"
 	"encoding/binary"
 	"io"
 	"log"
@@ -12,6 +11,7 @@ import (
 	"github.com/oiweiwei/go-msrpc/msrpc/dtyp"
 	"github.com/oiweiwei/go-msrpc/msrpc/lsat/lsarpc/v0"
 	"github.com/oiweiwei/go-msrpc/ndr"
+	"lukechampine.com/frand"
 )
 
 const (
@@ -85,7 +85,7 @@ func NewBindAck(callID uint32, addr string, contexts []*Context) *OutboundPacket
 	}
 
 	ag := make([]byte, 4)
-	rand.Read(ag)
+	frand.Read(ag)
 	packet := &OutboundPacket{
 		Header: NewHeader(PACKET_TYPE_BIND_ACK, PFC_FIRST_FRAG|PFC_LAST_FRAG, callID),
 		Body: &BindAck{

--- a/session.go
+++ b/session.go
@@ -5,7 +5,6 @@ import (
 	"crypto/aes"
 	"crypto/cipher"
 	"crypto/hmac"
-	"crypto/rand"
 	"crypto/sha256"
 	"crypto/sha512"
 	"encoding/binary"
@@ -21,6 +20,7 @@ import (
 	"github.com/mike76-dev/sombrero/kdf"
 	"github.com/mike76-dev/sombrero/ntlm"
 	"github.com/mike76-dev/sombrero/smb2"
+	"lukechampine.com/frand"
 )
 
 const (
@@ -66,7 +66,7 @@ func (s *server) registerSession(connection *connection, req smb2.SessionSetupRe
 	var found bool
 	if req.Header().SessionID() == 0 { // A new session
 		sid := make([]byte, 8)
-		rand.Read(sid)
+		frand.Read(sid)
 		ss = &session{
 			sessionID:        binary.LittleEndian.Uint64(sid),
 			connection:       connection,
@@ -349,7 +349,7 @@ func (ss *session) encrypt(buf []byte) []byte {
 		return nil
 	}
 	nonce := make([]byte, encrypter.NonceSize())
-	rand.Read(nonce)
+	frand.Read(nonce)
 	output := smb2.Header(make([]byte, smb2.SMB2TransformHeaderSize+len(buf)+16))
 	output.SetProtocolID(smb2.PROTOCOL_SMB2_ENCRYPTED)
 	output.SetNonce(nonce)

--- a/share.go
+++ b/share.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"context"
-	"crypto/rand"
 	"encoding/binary"
 	"errors"
 	"sync"
@@ -14,6 +13,7 @@ import (
 	proto "go.sia.tech/core/rhp/v4"
 	"go.sia.tech/core/types"
 	sdk "go.sia.tech/siastorage"
+	"lukechampine.com/frand"
 )
 
 const (
@@ -131,7 +131,7 @@ func (s *server) RegisterShare(ss stores.Share) error {
 	sh.mu.Unlock()
 
 	vid := make([]byte, 8)
-	rand.Read(vid[:])
+	frand.Read(vid[:])
 	sh.bucket = info.Bucket
 	sh.createdAt = time.Time(info.CreatedAt)
 	sh.volumeID = binary.LittleEndian.Uint64(vid)

--- a/share.go
+++ b/share.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/binary"
 	"errors"
+	"log"
 	"sync"
 	"time"
 
@@ -27,6 +28,15 @@ var (
 	errShareInUse       = errors.New("share currently in use by one or more clients")
 )
 
+// indexdConn holds the per-workgroup state for an indexd share connection.
+type indexdConn struct {
+	client        client.Client
+	maxUploadSize uint64
+	bucket        string
+	createdAt     time.Time
+	volumeID      uint64
+}
+
 // share represents a Share object.
 type share struct {
 	name            string
@@ -40,15 +50,18 @@ type share struct {
 	encryptData     bool
 	compressData    bool
 
-	// Auxiliary fields.
+	// For renterd shares (single client shared by all workgroups).
 	client        client.Client
 	maxUploadSize uint64
-	backend       string
 	bucket        string
-	appKey        types.PrivateKey
 	createdAt     time.Time
 	volumeID      uint64
-	mu            sync.Mutex
+
+	// For indexd shares (one client per workgroup connection).
+	indexdConns map[string]*indexdConn // keyed by workgroup UUID string
+
+	backend string
+	mu      sync.Mutex
 }
 
 // RegisterShare adds a new share to the SMB server.
@@ -68,7 +81,6 @@ func (s *server) RegisterShare(ss stores.Share) error {
 		maxUses:         maxShareUses,
 		bucket:          ss.Bucket,
 		remark:          ss.Remark,
-		appKey:          ss.AppKey,
 		connectSecurity: make(map[string]struct{}),
 		fileSecurity:    make(map[string]uint32),
 		encryptData:     s.encryptData,
@@ -77,74 +89,60 @@ func (s *server) RegisterShare(ss stores.Share) error {
 
 	switch sh.backend {
 	case "indexd":
-		builder := sdk.NewBuilder(ss.ServerName, sdk.AppMetadata{
-			ID:          types.HashBytes(append([]byte(s.cfg.Name), []byte(s.cfg.Description)...)),
-			Name:        s.cfg.Name,
-			Description: s.cfg.Description,
-			LogoURL:     s.cfg.LogoURL,
-			ServiceURL:  s.cfg.ServiceURL,
-		})
-		sdkClient, err := builder.SDK(ss.AppKey)
-		if err != nil {
-			return err
-		}
-		sh.client = client.NewIndexdClient(s.store, sdkClient, ss.Name, ss.DataShards, ss.ParityShards)
-		sh.maxUploadSize = uint64(ss.DataShards) * proto.SectorSize
+		sh.indexdConns = make(map[string]*indexdConn)
+		// Clients are initialized per-connection via AddConnection.
 	case "renterd":
 		sh.client = client.NewRenterdClient(ss.ServerName, ss.Password, ss.Bucket)
 		sh.maxUploadSize = proto.SectorSize
+
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		info, err := sh.client.Info(ctx)
+		if err != nil {
+			return errShareUnavailable
+		}
+		vid := make([]byte, 8)
+		frand.Read(vid[:])
+		sh.bucket = info.Bucket
+		sh.createdAt = time.Time(info.CreatedAt)
+		sh.volumeID = binary.LittleEndian.Uint64(vid)
 	default:
 		return errors.New("unsupported share type")
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-	defer cancel()
-
-	// Get the share information and test the share at the same time.
-	info, err := sh.client.Info(ctx)
-	if err != nil {
-		return errShareUnavailable
-	}
-
-	ars, err := s.store.GetAccounts(ss)
-	if err != nil {
-		return err
-	}
-
-	accs := make(map[int]stores.Account)
-	for _, ar := range ars {
-		if _, exists := accs[ar.AccountID]; !exists {
-			acc, err := s.store.GetAccountByID(ar.AccountID)
-			if err != nil {
-				return err
-			}
-			accs[ar.AccountID] = acc
+	// For renterd, pre-populate security maps from existing DB access rights.
+	// For indexd, security maps are populated when workgroups connect via AddConnection.
+	if sh.backend == "renterd" {
+		ars, err := s.store.GetAccounts(ss)
+		if err != nil {
+			return err
 		}
+
+		accs := make(map[int]stores.Account)
+		for _, ar := range ars {
+			if _, exists := accs[ar.AccountID]; !exists {
+				acc, err := s.store.GetAccountByID(ar.AccountID)
+				if err != nil {
+					return err
+				}
+				accs[ar.AccountID] = acc
+			}
+		}
+
+		sh.mu.Lock()
+		for _, ar := range ars {
+			acc := accs[ar.AccountID]
+			sh.connectSecurity[acc.Workgroup+"/"+acc.Username] = struct{}{}
+			sh.fileSecurity[acc.Workgroup+"/"+acc.Username] = stores.FlagsFromAccessRights(ar)
+		}
+		sh.mu.Unlock()
 	}
 
-	sh.mu.Lock()
-	for _, ar := range ars {
-		acc := accs[ar.AccountID]
-		sh.connectSecurity[acc.Workgroup+"/"+acc.Username] = struct{}{}
-		sh.fileSecurity[acc.Workgroup+"/"+acc.Username] = stores.FlagsFromAccessRights(ar)
-	}
-	sh.mu.Unlock()
-
-	vid := make([]byte, 8)
-	frand.Read(vid[:])
-	sh.bucket = info.Bucket
-	sh.createdAt = time.Time(info.CreatedAt)
-	sh.volumeID = binary.LittleEndian.Uint64(vid)
 	s.mu.Lock()
 	s.shareList[sh.name] = sh
 	s.mu.Unlock()
 
 	return nil
-}
-
-// serialNo is a helper function that derives the share's "serial number" from its "volume ID".
-func (sh *share) serialNo() uint32 {
-	return uint32(sh.volumeID)
 }
 
 // RemoveShare removes a share from the SMB server.
@@ -163,10 +161,21 @@ func (s *server) RemoveShare(ss stores.Share) error {
 	}
 	sh.mu.Unlock()
 
-	if err := sh.client.DeleteAll(s.ctx); err != nil {
-		return err
-	} else if err := sh.client.Close(); err != nil {
-		return err
+	switch sh.backend {
+	case "renterd":
+		if sh.client != nil {
+			if err := sh.client.DeleteAll(s.ctx); err != nil {
+				return err
+			} else if err := sh.client.Close(); err != nil {
+				return err
+			}
+		}
+	case "indexd":
+		for _, conn := range sh.indexdConns {
+			if err := conn.client.Close(); err != nil {
+				log.Printf("close indexd client: %v", err)
+			}
+		}
 	}
 
 	s.mu.Lock()
@@ -188,6 +197,16 @@ func (s *server) UpdateAccessRights(ss stores.Share, ar stores.AccessRights) err
 	acc, err := s.store.GetAccountByID(ar.AccountID)
 	if err != nil {
 		return err
+	}
+
+	// For indexd, only update security maps for connected workgroups.
+	if sh.backend == "indexd" {
+		sh.mu.Lock()
+		_, hasConn := sh.indexdConns[acc.Workgroup]
+		sh.mu.Unlock()
+		if !hasConn {
+			return nil
+		}
 	}
 
 	sh.mu.Lock()
@@ -213,4 +232,117 @@ func (s *server) RemoveAccess(acc stores.Account) {
 		sh.mu.Unlock()
 	}
 	s.mu.Unlock()
+}
+
+// AddConnection initializes a per-workgroup indexd SDK client and populates
+// the security maps for the connecting workgroup's accounts.
+func (s *server) AddConnection(wg stores.Workgroup, share stores.Share, appKey types.PrivateKey) error {
+	s.mu.Lock()
+	sh, found := s.shareList[share.Name]
+	s.mu.Unlock()
+	if !found {
+		if err := s.RegisterShare(share); err != nil {
+			return err
+		}
+		s.mu.Lock()
+		sh, found = s.shareList[share.Name]
+		s.mu.Unlock()
+		if !found {
+			return errShareNotFound
+		}
+	}
+
+	if sh.backend == "indexd" {
+		builder := sdk.NewBuilder(share.ServerName, sdk.AppMetadata{
+			ID:          types.HashBytes(append([]byte(s.cfg.Name), []byte(s.cfg.Description)...)),
+			Name:        s.cfg.Name,
+			Description: s.cfg.Description,
+			LogoURL:     s.cfg.LogoURL,
+			ServiceURL:  s.cfg.ServiceURL,
+		})
+		sdkClient, err := builder.SDK(appKey)
+		if err != nil {
+			return err
+		}
+		c := client.NewIndexdClient(s.store, sdkClient, share.Name, share.DataShards, share.ParityShards)
+
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		info, err := c.Info(ctx)
+		if err != nil {
+			return errShareUnavailable
+		}
+
+		vid := make([]byte, 8)
+		frand.Read(vid[:])
+
+		conn := &indexdConn{
+			client:        c,
+			maxUploadSize: uint64(share.DataShards) * proto.SectorSize,
+			bucket:        info.Bucket,
+			createdAt:     time.Time(info.CreatedAt),
+			volumeID:      binary.LittleEndian.Uint64(vid),
+		}
+
+		sh.mu.Lock()
+		sh.indexdConns[wg.UUID.String()] = conn
+		sh.mu.Unlock()
+	}
+
+	accs, err := s.store.FindAccounts(wg.UUID.String())
+	if err != nil {
+		return err
+	}
+
+	sh.mu.Lock()
+	for _, acc := range accs {
+		ar, err := s.store.GetAccessRights(share, acc)
+		if err != nil {
+			sh.mu.Unlock()
+			return err
+		}
+		if ar.AccountID != 0 && (ar.ReadAccess || ar.WriteAccess || ar.DeleteAccess || ar.ExecuteAccess) {
+			sh.connectSecurity[acc.Workgroup+"/"+acc.Username] = struct{}{}
+			sh.fileSecurity[acc.Workgroup+"/"+acc.Username] = stores.FlagsFromAccessRights(ar)
+		}
+	}
+	sh.mu.Unlock()
+
+	return nil
+}
+
+// RemoveConnection closes the workgroup's indexd client and removes their
+// accounts from the share's security maps.
+func (s *server) RemoveConnection(wg stores.Workgroup, share stores.Share) error {
+	s.mu.Lock()
+	sh, found := s.shareList[share.Name]
+	s.mu.Unlock()
+	if !found {
+		return nil
+	}
+
+	if sh.backend == "indexd" {
+		sh.mu.Lock()
+		if conn, ok := sh.indexdConns[wg.UUID.String()]; ok {
+			if err := conn.client.Close(); err != nil {
+				log.Printf("close indexd client: %v", err)
+			}
+			delete(sh.indexdConns, wg.UUID.String())
+		}
+		sh.mu.Unlock()
+	}
+
+	accs, err := s.store.FindAccounts(wg.UUID.String())
+	if err != nil {
+		return err
+	}
+
+	sh.mu.Lock()
+	for _, acc := range accs {
+		delete(sh.connectSecurity, acc.Workgroup+"/"+acc.Username)
+		delete(sh.fileSecurity, acc.Workgroup+"/"+acc.Username)
+	}
+	sh.mu.Unlock()
+
+	return nil
 }

--- a/smb2/query.go
+++ b/smb2/query.go
@@ -1,7 +1,6 @@
 package smb2
 
 import (
-	"crypto/rand"
 	"encoding/binary"
 	"time"
 
@@ -11,6 +10,7 @@ import (
 	"github.com/oiweiwei/go-msrpc/msrpc/dtyp"
 	"github.com/oiweiwei/go-msrpc/ndr"
 	"golang.org/x/crypto/blake2b"
+	"lukechampine.com/frand"
 )
 
 const (
@@ -634,7 +634,7 @@ func QueryDirectoryBuffer(class uint8, entries []client.ObjectInfo, bufSize uint
 		hash := blake2b.Sum256([]byte(entry.Key))
 		di.FileID64 = binary.LittleEndian.Uint64(hash[:8])
 		di.FileID128 = make([]byte, 16)
-		rand.Read(di.FileID128)
+		frand.Read(di.FileID128)
 
 		info = append(info, di)
 		num++

--- a/smb2/request.go
+++ b/smb2/request.go
@@ -1,11 +1,11 @@
 package smb2
 
 import (
-	"crypto/rand"
 	"encoding/binary"
 	"errors"
 
 	"github.com/mike76-dev/sombrero/utils"
+	"lukechampine.com/frand"
 )
 
 var (
@@ -125,7 +125,7 @@ func GetRequests(data []byte, cid uint64, tsid uint64, compressed bool) (reqs []
 	// Assign a group ID to all related requests.
 	if related {
 		gid := make([]byte, 8)
-		rand.Read(gid)
+		frand.Read(gid)
 		groupID := binary.LittleEndian.Uint64(gid)
 		for _, req := range reqs {
 			req.groupID = groupID

--- a/stores/accounts.go
+++ b/stores/accounts.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
 	"github.com/mike76-dev/sombrero/utils"
 	"golang.org/x/crypto/md4"
@@ -24,36 +25,43 @@ type Account struct {
 func (db *Database) GetAccountByID(id int) (acc Account, err error) {
 	err = db.txn(func(ctx context.Context, tx pgx.Tx) error {
 		const query = `
-			SELECT account_name, password_hash, workgroup
-			FROM accounts
-			WHERE id = $1
+			SELECT a.account_name, a.password_hash, w.uuid
+			FROM accounts a
+			JOIN workgroups w ON w.id = a.workgroup
+			WHERE a.id = $1
 		`
-		var username, workgroup string
+		var username string
 		var pwh []byte
-		err = tx.QueryRow(ctx, query, id).Scan(&username, &pwh, &workgroup)
+		var u uuid.UUID
+		err = tx.QueryRow(ctx, query, id).Scan(&username, &pwh, &u)
 		if errors.Is(err, sql.ErrNoRows) {
 			return nil
 		} else if err != nil {
 			return fmt.Errorf("failed to retrieve account: %w", err)
 		}
-		acc = Account{id, username, "", pwh, workgroup}
+		acc = Account{id, username, "", pwh, u.String()}
 		return nil
 	})
 	return
 }
 
-// FindAccount tries to retrieve the account by the username and the workgroup.
+// FindAccount tries to retrieve the account by the username and the workgroup UUID.
 func (db *Database) FindAccount(username, workgroup string) (acc Account, err error) {
+	u, err := uuid.Parse(workgroup)
+	if err != nil {
+		return acc, fmt.Errorf("invalid workgroup UUID: %w", err)
+	}
 	err = db.txn(func(ctx context.Context, tx pgx.Tx) error {
 		const query = `
-			SELECT id, password_hash
-			FROM accounts
-			WHERE account_name = $1
-			AND workgroup = $2
+			SELECT a.id, a.password_hash
+			FROM accounts a
+			JOIN workgroups w ON w.id = a.workgroup
+			WHERE a.account_name = $1
+			AND w.uuid = $2
 		`
 		var id int
 		var pwh []byte
-		err = tx.QueryRow(ctx, query, username, workgroup).Scan(&id, &pwh)
+		err = tx.QueryRow(ctx, query, username, u[:]).Scan(&id, &pwh)
 		if errors.Is(err, sql.ErrNoRows) {
 			return nil
 		} else if err != nil {
@@ -67,17 +75,21 @@ func (db *Database) FindAccount(username, workgroup string) (acc Account, err er
 
 // AddAccount adds a new account to the database.
 func (db *Database) AddAccount(acc Account) error {
+	u, err := uuid.Parse(acc.Workgroup)
+	if err != nil {
+		return fmt.Errorf("invalid workgroup UUID: %w", err)
+	}
 	return db.txn(func(ctx context.Context, tx pgx.Tx) error {
 		const query = `
 			INSERT INTO accounts (account_name, password_hash, workgroup)
-			VALUES ($1, $2, $3)
+			VALUES ($1, $2, (SELECT id FROM workgroups WHERE uuid = $3))
 		`
 
 		h := md4.New()
 		h.Write(utils.EncodeStringToBytes(acc.Password))
 		acc.NTHash = h.Sum(nil)
 
-		_, err := tx.Exec(ctx, query, acc.Username, acc.NTHash, acc.Workgroup)
+		_, err := tx.Exec(ctx, query, acc.Username, acc.NTHash, u[:])
 		if err != nil {
 			return fmt.Errorf("failed to add account: %w", err)
 		} else {
@@ -88,28 +100,37 @@ func (db *Database) AddAccount(acc Account) error {
 
 // HasAccount returns true if there is such account in the database.
 func (db *Database) HasAccount(username, workgroup string) (bool, error) {
+	u, err := uuid.Parse(workgroup)
+	if err != nil {
+		return false, fmt.Errorf("invalid workgroup UUID: %w", err)
+	}
 	var count int
-	err := db.txn(func(ctx context.Context, tx pgx.Tx) error {
+	err = db.txn(func(ctx context.Context, tx pgx.Tx) error {
 		const query = `
 			SELECT COUNT(*)
-			FROM accounts
-			WHERE account_name = $1
-			AND workgroup = $2
+			FROM accounts a
+			JOIN workgroups w ON w.id = a.workgroup
+			WHERE a.account_name = $1
+			AND w.uuid = $2
 		`
-		return tx.QueryRow(ctx, query, username, workgroup).Scan(&count)
+		return tx.QueryRow(ctx, query, username, u[:]).Scan(&count)
 	})
 	return count > 0, err
 }
 
 // RemoveAccount removes the specified account from the database.
 func (db *Database) RemoveAccount(username, workgroup string) error {
+	u, err := uuid.Parse(workgroup)
+	if err != nil {
+		return fmt.Errorf("invalid workgroup UUID: %w", err)
+	}
 	return db.txn(func(ctx context.Context, tx pgx.Tx) error {
 		const query = `
 			DELETE FROM accounts
 			WHERE account_name = $1
-			AND workgroup = $2
+			AND workgroup = (SELECT id FROM workgroups WHERE uuid = $2)
 		`
-		_, err := tx.Exec(ctx, query, username, workgroup)
+		_, err := tx.Exec(ctx, query, username, u[:])
 		if err != nil {
 			return fmt.Errorf("failed to remove account: %w", err)
 		} else {
@@ -120,13 +141,18 @@ func (db *Database) RemoveAccount(username, workgroup string) error {
 
 // FindAccounts returns all accounts of the specified workgroup.
 func (db *Database) FindAccounts(workgroup string) (accs []Account, err error) {
+	u, err := uuid.Parse(workgroup)
+	if err != nil {
+		return nil, fmt.Errorf("invalid workgroup UUID: %w", err)
+	}
 	err = db.txn(func(ctx context.Context, tx pgx.Tx) error {
 		const query = `
-			SELECT id, account_name, password_hash
-			FROM accounts
-			WHERE workgroup = $1
+			SELECT a.id, a.account_name, a.password_hash
+			FROM accounts a
+			JOIN workgroups w ON w.id = a.workgroup
+			WHERE w.uuid = $1
 		`
-		rows, err := tx.Query(ctx, query, workgroup)
+		rows, err := tx.Query(ctx, query, u[:])
 		if err != nil {
 			return fmt.Errorf("failed to fetch accounts: %w", err)
 		}
@@ -153,12 +179,16 @@ func (db *Database) FindAccounts(workgroup string) (accs []Account, err error) {
 
 // RemoveAccounts removes all accounts of the specified workgroup.
 func (db *Database) RemoveAccounts(workgroup string) error {
+	u, err := uuid.Parse(workgroup)
+	if err != nil {
+		return fmt.Errorf("invalid workgroup UUID: %w", err)
+	}
 	return db.txn(func(ctx context.Context, tx pgx.Tx) error {
 		const query = `
 			DELETE FROM accounts
-			WHERE workgroup = $1
+			WHERE workgroup = (SELECT id FROM workgroups WHERE uuid = $1)
 		`
-		_, err := tx.Exec(ctx, query, workgroup)
+		_, err := tx.Exec(ctx, query, u[:])
 		if err != nil {
 			return fmt.Errorf("failed to remove accounts: %w", err)
 		} else {

--- a/stores/connect.go
+++ b/stores/connect.go
@@ -22,6 +22,9 @@ func (db *Database) AddConnection(wg Workgroup, share Share, appKey types.Privat
 		if err != nil {
 			return fmt.Errorf("failed to add connection: %w", err)
 		}
+		if err := db.shares.AddConnection(wg, share, appKey); err != nil {
+			return fmt.Errorf("failed to connect share: %w", err)
+		}
 		return nil
 	})
 }
@@ -37,6 +40,9 @@ func (db *Database) RemoveConnection(wg Workgroup, share Share) error {
 		_, err := tx.Exec(ctx, query, wg.ID, share.Name)
 		if err != nil {
 			return fmt.Errorf("failed to remove connection: %w", err)
+		}
+		if err := db.shares.RemoveConnection(wg, share); err != nil {
+			return fmt.Errorf("failed to disconnect share: %w", err)
 		}
 		return nil
 	})

--- a/stores/connect.go
+++ b/stores/connect.go
@@ -1,0 +1,81 @@
+package stores
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+
+	"github.com/jackc/pgx/v5"
+	"go.sia.tech/core/types"
+)
+
+// AddConnection creates a connection between a workgroup and a share.
+func (db *Database) AddConnection(wg Workgroup, share Share, appKey types.PrivateKey) error {
+	return db.txn(func(ctx context.Context, tx pgx.Tx) error {
+		const query = `
+			INSERT INTO connections (workgroup, share_name, app_key)
+			VALUES ($1, $2, $3)
+			ON CONFLICT (workgroup, share_name) DO NOTHING
+		`
+		_, err := tx.Exec(ctx, query, wg.ID, share.Name, appKey)
+		if err != nil {
+			return fmt.Errorf("failed to add connection: %w", err)
+		}
+		return nil
+	})
+}
+
+// RemoveConnection removes the connection between a workgroup and a share.
+func (db *Database) RemoveConnection(wg Workgroup, share Share) error {
+	return db.txn(func(ctx context.Context, tx pgx.Tx) error {
+		const query = `
+			DELETE FROM connections
+			WHERE workgroup = $1
+			AND share_name = $2
+		`
+		_, err := tx.Exec(ctx, query, wg.ID, share.Name)
+		if err != nil {
+			return fmt.Errorf("failed to remove connection: %w", err)
+		}
+		return nil
+	})
+}
+
+// IsConnected checks if a connection exists between a workgroup and a share.
+func (db *Database) IsConnected(wg Workgroup, share Share) (bool, types.PrivateKey, error) {
+	var appKey types.PrivateKey
+	var connected bool
+	err := db.txn(func(ctx context.Context, tx pgx.Tx) error {
+		const query = `
+			SELECT app_key
+			FROM connections
+			WHERE workgroup = $1
+			AND share_name = $2
+		`
+		err := tx.QueryRow(ctx, query, wg.ID, share.Name).Scan(&appKey)
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil
+		}
+		connected = true
+		return nil
+	})
+	return connected, appKey, err
+}
+
+// SetAppKey sets the app key for the connection between a workgroup and a share.
+func (db *Database) SetAppKey(wg Workgroup, share Share, key types.PrivateKey) error {
+	return db.txn(func(ctx context.Context, tx pgx.Tx) error {
+		const query = `
+			UPDATE connections
+			SET app_key = $3
+			WHERE workgroup = $1
+			AND share_name = $2
+		`
+		_, err := tx.Exec(ctx, query, wg.ID, share.Name, key)
+		if err != nil {
+			return fmt.Errorf("failed to set connection key: %w", err)
+		}
+		return nil
+	})
+}

--- a/stores/database.go
+++ b/stores/database.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
+	"go.sia.tech/core/types"
 )
 
 // Database represents a PostgreSQL-backed store.
@@ -22,6 +23,8 @@ type Shares interface {
 	RemoveShare(sh Share) error
 	UpdateAccessRights(ss Share, ar AccessRights) error
 	RemoveAccess(acc Account)
+	AddConnection(wg Workgroup, share Share, appKey types.PrivateKey) error
+	RemoveConnection(wg Workgroup, share Share) error
 }
 
 // Close closes the underlying database connection.

--- a/stores/filesystem.go
+++ b/stores/filesystem.go
@@ -382,6 +382,7 @@ func (db *Database) CreateDirectory(acc Account, share string, path string, priv
 				name,
 				full_path,
 				account,
+				workgroup,
 				private
 			)
 			SELECT
@@ -392,9 +393,11 @@ func (db *Database) CreateDirectory(acc Account, share string, path string, priv
 					WHEN p.full_path = '/' THEN '/' || $4
 					ELSE p.full_path || '/' || $4
 				END,
-				$3,
+				c.id,
+				c.workgroup,
 				$5
 			FROM parent p
+			CROSS JOIN caller c
 			RETURNING id
 		`
 		var id uint64

--- a/stores/main_test.go
+++ b/stores/main_test.go
@@ -1,0 +1,24 @@
+package stores
+
+import (
+	"os"
+	"syscall"
+	"testing"
+)
+
+// TestMain serializes this package's DB access against other test packages
+// that share the same sombrero_test PostgreSQL database.
+func TestMain(m *testing.M) {
+	f, err := os.OpenFile("/tmp/sombrero_test.lock", os.O_CREATE|os.O_RDWR, 0600)
+	if err != nil {
+		panic(err)
+	}
+	if err := syscall.Flock(int(f.Fd()), syscall.LOCK_EX); err != nil {
+		f.Close()
+		panic(err)
+	}
+	code := m.Run()
+	syscall.Flock(int(f.Fd()), syscall.LOCK_UN) //nolint
+	f.Close()
+	os.Exit(code)
+}

--- a/stores/policy.go
+++ b/stores/policy.go
@@ -52,6 +52,7 @@ func (db *Database) GetAccessRights(share Share, acc Account) (ar AccessRights, 
 }
 
 // SetAccessRights stores the access policy in the database.
+// Returns an error if no connection exists between the account's workgroup and the share.
 func (db *Database) SetAccessRights(ar AccessRights) error {
 	sh, err := db.GetShare(ar.ShareName)
 	if err != nil {
@@ -59,8 +60,8 @@ func (db *Database) SetAccessRights(ar AccessRights) error {
 	}
 	return db.txn(func(ctx context.Context, tx pgx.Tx) error {
 		const query = `
-			INSERT INTO policies (share_name, account, read_access, write_access, delete_access, execute_access)
-			VALUES ($1, $2, $3, $4, $5, $6)
+			INSERT INTO policies (share_name, account, workgroup, read_access, write_access, delete_access, execute_access)
+			VALUES ($1, $2, (SELECT workgroup FROM accounts WHERE id = $2), $3, $4, $5, $6)
 			ON CONFLICT (share_name, account) DO UPDATE
 			SET read_access = EXCLUDED.read_access,
 				write_access = EXCLUDED.write_access,

--- a/stores/policy.go
+++ b/stores/policy.go
@@ -53,6 +53,10 @@ func (db *Database) GetAccessRights(share Share, acc Account) (ar AccessRights, 
 
 // SetAccessRights stores the access policy in the database.
 func (db *Database) SetAccessRights(ar AccessRights) error {
+	sh, err := db.GetShare(ar.ShareName)
+	if err != nil {
+		return fmt.Errorf("failed to retrieve share: %w", err)
+	}
 	return db.txn(func(ctx context.Context, tx pgx.Tx) error {
 		const query = `
 			INSERT INTO policies (share_name, account, read_access, write_access, delete_access, execute_access)
@@ -66,15 +70,11 @@ func (db *Database) SetAccessRights(ar AccessRights) error {
 		_, err := tx.Exec(ctx, query, ar.ShareName, ar.AccountID, ar.ReadAccess, ar.WriteAccess, ar.DeleteAccess, ar.ExecuteAccess)
 		if err != nil {
 			return fmt.Errorf("failed to update policy: %w", err)
-		} else {
-			sh, err := db.GetShare(ar.ShareName)
-			if err != nil {
-				return fmt.Errorf("failed to retrieve share: %w", err)
-			} else if err := db.shares.UpdateAccessRights(sh, ar); err != nil {
-				return fmt.Errorf("failed to update access rights: %w", err)
-			}
-			return nil
 		}
+		if err := db.shares.UpdateAccessRights(sh, ar); err != nil {
+			return fmt.Errorf("failed to update access rights: %w", err)
+		}
+		return nil
 	})
 }
 

--- a/stores/shares.go
+++ b/stores/shares.go
@@ -8,21 +8,19 @@ import (
 	"time"
 
 	"github.com/jackc/pgx/v5"
-	"go.sia.tech/core/types"
 )
 
 // Share represents a renterd bucket, which is mounted as a remote share.
 type Share struct {
-	Name         string           `json:"name"`
-	Type         string           `json:"type"`
-	ServerName   string           `json:"serverName"`
-	Password     string           `json:"password,omitempty"`
-	Bucket       string           `json:"bucket,omitempty"`
-	Remark       string           `json:"remark,omitempty"`
-	CreatedAt    time.Time        `json:"createdAt,omitempty"`
-	DataShards   uint8            `json:"dataShards,omitempty"`
-	ParityShards uint8            `json:"parityShards,omitempty"`
-	AppKey       types.PrivateKey `json:"-"`
+	Name         string    `json:"name"`
+	Type         string    `json:"type"`
+	ServerName   string    `json:"serverName"`
+	Password     string    `json:"password,omitempty"`
+	Bucket       string    `json:"bucket,omitempty"`
+	Remark       string    `json:"remark,omitempty"`
+	CreatedAt    time.Time `json:"createdAt,omitempty"`
+	DataShards   uint8     `json:"dataShards,omitempty"`
+	ParityShards uint8     `json:"parityShards,omitempty"`
 }
 
 // RegisterShare registers a new share in the database.
@@ -38,12 +36,11 @@ func (db *Database) RegisterShare(s Share) error {
 				remark,
 				created_at,
 				data_shards,
-				parity_shards,
-				app_key
+				parity_shards
 			)
-			VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
+			VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
 		`
-		_, err := tx.Exec(ctx, query, s.Name, s.Type, s.ServerName, s.Password, s.Bucket, s.Remark, time.Now(), s.DataShards, s.ParityShards, s.AppKey)
+		_, err := tx.Exec(ctx, query, s.Name, s.Type, s.ServerName, s.Password, s.Bucket, s.Remark, time.Now(), s.DataShards, s.ParityShards)
 		if err != nil {
 			return fmt.Errorf("failed to register share: %w", err)
 		} else if err := db.shares.RegisterShare(s); err != nil {
@@ -100,16 +97,14 @@ func (db *Database) GetShare(name string) (s Share, err error) {
 				remark,
 				created_at,
 				data_shards,
-				parity_shards,
-				app_key
+				parity_shards
 			FROM shares
 			WHERE share_name = $1
 		`
 		var backend, server, password, bucket, remark string
 		var created time.Time
 		var dataShards, parityShards int
-		var appKey types.PrivateKey
-		err = tx.QueryRow(ctx, query, name).Scan(&backend, &server, &password, &bucket, &remark, &created, &dataShards, &parityShards, &appKey)
+		err = tx.QueryRow(ctx, query, name).Scan(&backend, &server, &password, &bucket, &remark, &created, &dataShards, &parityShards)
 		if errors.Is(err, sql.ErrNoRows) {
 			return nil
 		} else if err != nil {
@@ -125,7 +120,6 @@ func (db *Database) GetShare(name string) (s Share, err error) {
 			CreatedAt:    created,
 			DataShards:   uint8(dataShards),
 			ParityShards: uint8(parityShards),
-			AppKey:       appKey,
 		}
 		return nil
 	})
@@ -145,8 +139,7 @@ func (db *Database) GetShares(acc Account) (shares []Share, err error) {
 				s.remark,
 				s.created_at,
 				s.data_shards,
-				s.parity_shards,
-				s.app_key
+				s.parity_shards
 			FROM shares AS s
 			JOIN policies AS p
 			ON p.share_name = s.share_name
@@ -165,8 +158,7 @@ func (db *Database) GetShares(acc Account) (shares []Share, err error) {
 			var name, backend, server, password, bucket, remark string
 			var created time.Time
 			var dataShards, parityShards int
-			var appKey types.PrivateKey
-			if err := rows.Scan(&name, &backend, &server, &password, &bucket, &remark, &created, &dataShards, &parityShards, &appKey); err != nil {
+			if err := rows.Scan(&name, &backend, &server, &password, &bucket, &remark, &created, &dataShards, &parityShards); err != nil {
 				return fmt.Errorf("failed to retrieve share: %w", err)
 			}
 			shares = append(shares, Share{
@@ -179,7 +171,6 @@ func (db *Database) GetShares(acc Account) (shares []Share, err error) {
 				CreatedAt:    created,
 				DataShards:   uint8(dataShards),
 				ParityShards: uint8(parityShards),
-				AppKey:       appKey,
 			})
 		}
 		return nil

--- a/stores/stores_test.go
+++ b/stores/stores_test.go
@@ -24,6 +24,7 @@ func TestWorkgroups(t *testing.T) {
 
 	u := uuid.New()
 
+	// Add without name.
 	if err := db.AddWorkgroup(Workgroup{UUID: u}); err != nil {
 		t.Fatalf("AddWorkgroup: %v", err)
 	}
@@ -38,6 +39,9 @@ func TestWorkgroups(t *testing.T) {
 	}
 	if wg.ID == 0 {
 		t.Fatal("FindWorkgroup: expected non-zero ID")
+	}
+	if wg.Name != "" {
+		t.Fatalf("FindWorkgroup: expected empty name, got %q", wg.Name)
 	}
 
 	// GetWorkgroupByID.
@@ -68,6 +72,42 @@ func TestWorkgroups(t *testing.T) {
 	}
 	if gone.ID != 0 {
 		t.Fatal("FindWorkgroup after remove: expected zero value")
+	}
+
+	// Add with name.
+	u2 := uuid.New()
+	if err := db.AddWorkgroup(Workgroup{UUID: u2, Name: "acme"}); err != nil {
+		t.Fatalf("AddWorkgroup with name: %v", err)
+	}
+
+	// FindWorkgroupByName.
+	wg2, err := db.FindWorkgroupByName("acme")
+	if err != nil {
+		t.Fatalf("FindWorkgroupByName: %v", err)
+	}
+	if wg2.UUID != u2 {
+		t.Fatalf("FindWorkgroupByName: want UUID %v, got %v", u2, wg2.UUID)
+	}
+	if wg2.Name != "acme" {
+		t.Fatalf("FindWorkgroupByName: want name %q, got %q", "acme", wg2.Name)
+	}
+
+	// FindWorkgroup by UUID also returns the name.
+	wg2ByUUID, err := db.FindWorkgroup(u2)
+	if err != nil {
+		t.Fatalf("FindWorkgroup (named): %v", err)
+	}
+	if wg2ByUUID.Name != "acme" {
+		t.Fatalf("FindWorkgroup (named): want name %q, got %q", "acme", wg2ByUUID.Name)
+	}
+
+	// FindWorkgroupByName for unknown name returns zero value.
+	noWG, err := db.FindWorkgroupByName("unknown")
+	if err != nil {
+		t.Fatalf("FindWorkgroupByName missing: %v", err)
+	}
+	if noWG.ID != 0 {
+		t.Fatal("FindWorkgroupByName missing: expected zero value")
 	}
 }
 

--- a/stores/stores_test.go
+++ b/stores/stores_test.go
@@ -284,6 +284,10 @@ func TestGetShares(t *testing.T) {
 	if err := db.AddWorkgroup(Workgroup{UUID: u}); err != nil {
 		t.Fatalf("AddWorkgroup: %v", err)
 	}
+	wg, err := db.FindWorkgroup(u)
+	if err != nil {
+		t.Fatalf("FindWorkgroup: %v", err)
+	}
 	if err := db.AddAccount(Account{Username: "user1", Password: "pw", Workgroup: u.String()}); err != nil {
 		t.Fatalf("AddAccount: %v", err)
 	}
@@ -296,6 +300,14 @@ func TestGetShares(t *testing.T) {
 		if err := db.RegisterShare(Share{Name: name, Type: "renterd", ServerName: "srv"}); err != nil {
 			t.Fatalf("RegisterShare %s: %v", name, err)
 		}
+	}
+
+	shareA, err := db.GetShare("shareA")
+	if err != nil {
+		t.Fatalf("GetShare shareA: %v", err)
+	}
+	if err := db.AddConnection(wg, shareA, makeKey(t)); err != nil {
+		t.Fatalf("AddConnection: %v", err)
 	}
 
 	// Grant read access to shareA only.
@@ -429,6 +441,10 @@ func TestPolicies(t *testing.T) {
 	if err := db.AddWorkgroup(Workgroup{UUID: u}); err != nil {
 		t.Fatalf("AddWorkgroup: %v", err)
 	}
+	wg, err := db.FindWorkgroup(u)
+	if err != nil {
+		t.Fatalf("FindWorkgroup: %v", err)
+	}
 	if err := db.AddAccount(Account{Username: "puser", Password: "pw", Workgroup: u.String()}); err != nil {
 		t.Fatalf("AddAccount: %v", err)
 	}
@@ -451,6 +467,16 @@ func TestPolicies(t *testing.T) {
 	}
 	if ar.AccountID != 0 {
 		t.Fatal("GetAccessRights pre-set: expected zero value")
+	}
+
+	// SetAccessRights without a connection must be rejected.
+	if err := db.SetAccessRights(AccessRights{ShareName: share.Name, AccountID: acc.ID, ReadAccess: true}); err == nil {
+		t.Fatal("SetAccessRights without connection: expected error, got nil")
+	}
+
+	// Establish connection so policy operations are now permitted.
+	if err := db.AddConnection(wg, share, makeKey(t)); err != nil {
+		t.Fatalf("AddConnection: %v", err)
 	}
 
 	// SetAccessRights.
@@ -518,6 +544,26 @@ func TestPolicies(t *testing.T) {
 	}
 	if len(ars) != 0 {
 		t.Fatalf("GetAccounts after clear: want 0, got %d", len(ars))
+	}
+
+	// RemoveConnection cascades and clears all policies for the workgroup on that share.
+	if err := db.SetAccessRights(want); err != nil {
+		t.Fatalf("SetAccessRights before disconnect: %v", err)
+	}
+	if err := db.RemoveConnection(wg, share); err != nil {
+		t.Fatalf("RemoveConnection: %v", err)
+	}
+	ar, err = db.GetAccessRights(share, acc)
+	if err != nil {
+		t.Fatalf("GetAccessRights after disconnect: %v", err)
+	}
+	if ar.AccountID != 0 {
+		t.Fatal("GetAccessRights after disconnect: expected policy to be cascade-deleted")
+	}
+
+	// SetAccessRights without a connection must again be rejected.
+	if err := db.SetAccessRights(want); err == nil {
+		t.Fatal("SetAccessRights after disconnect: expected error, got nil")
 	}
 }
 

--- a/stores/stores_test.go
+++ b/stores/stores_test.go
@@ -1,0 +1,504 @@
+package stores
+
+import (
+	"bytes"
+	"context"
+	"testing"
+
+	"github.com/google/uuid"
+	"go.sia.tech/core/types"
+	"lukechampine.com/frand"
+)
+
+func makeKey(t *testing.T) types.PrivateKey {
+	t.Helper()
+	key := make(types.PrivateKey, 64)
+	frand.Read(key)
+	return key
+}
+
+func TestWorkgroups(t *testing.T) {
+	ctx := context.Background()
+	db := NewTestStore(t, ctx)
+	defer db.Close()
+
+	u := uuid.New()
+
+	if err := db.AddWorkgroup(Workgroup{UUID: u}); err != nil {
+		t.Fatalf("AddWorkgroup: %v", err)
+	}
+
+	// FindWorkgroup by UUID.
+	wg, err := db.FindWorkgroup(u)
+	if err != nil {
+		t.Fatalf("FindWorkgroup: %v", err)
+	}
+	if wg.UUID != u {
+		t.Fatalf("FindWorkgroup: want UUID %v, got %v", u, wg.UUID)
+	}
+	if wg.ID == 0 {
+		t.Fatal("FindWorkgroup: expected non-zero ID")
+	}
+
+	// GetWorkgroupByID.
+	byID, err := db.GetWorkgroupByID(wg.ID)
+	if err != nil {
+		t.Fatalf("GetWorkgroupByID: %v", err)
+	}
+	if byID.UUID != u {
+		t.Fatalf("GetWorkgroupByID: want UUID %v, got %v", u, byID.UUID)
+	}
+
+	// FindWorkgroup for unknown UUID returns zero value.
+	missing, err := db.FindWorkgroup(uuid.New())
+	if err != nil {
+		t.Fatalf("FindWorkgroup missing: %v", err)
+	}
+	if missing.ID != 0 {
+		t.Fatal("FindWorkgroup missing: expected zero value")
+	}
+
+	// RemoveWorkgroup.
+	if err := db.RemoveWorkgroup(wg); err != nil {
+		t.Fatalf("RemoveWorkgroup: %v", err)
+	}
+	gone, err := db.FindWorkgroup(u)
+	if err != nil {
+		t.Fatalf("FindWorkgroup after remove: %v", err)
+	}
+	if gone.ID != 0 {
+		t.Fatal("FindWorkgroup after remove: expected zero value")
+	}
+}
+
+func TestAccounts(t *testing.T) {
+	ctx := context.Background()
+	db := NewTestStore(t, ctx)
+	defer db.Close()
+
+	u := uuid.New()
+	if err := db.AddWorkgroup(Workgroup{UUID: u}); err != nil {
+		t.Fatalf("AddWorkgroup: %v", err)
+	}
+
+	acc := Account{Username: "alice", Password: "s3cr3t", Workgroup: u.String()}
+	if err := db.AddAccount(acc); err != nil {
+		t.Fatalf("AddAccount: %v", err)
+	}
+
+	// HasAccount.
+	has, err := db.HasAccount(acc.Username, acc.Workgroup)
+	if err != nil {
+		t.Fatalf("HasAccount: %v", err)
+	}
+	if !has {
+		t.Fatal("HasAccount: expected true")
+	}
+
+	// HasAccount for unknown user.
+	has, err = db.HasAccount("nobody", acc.Workgroup)
+	if err != nil {
+		t.Fatalf("HasAccount missing: %v", err)
+	}
+	if has {
+		t.Fatal("HasAccount missing: expected false")
+	}
+
+	// FindAccount.
+	found, err := db.FindAccount(acc.Username, acc.Workgroup)
+	if err != nil {
+		t.Fatalf("FindAccount: %v", err)
+	}
+	if found.Username != acc.Username {
+		t.Fatalf("FindAccount: want username %q, got %q", acc.Username, found.Username)
+	}
+	if found.Workgroup != acc.Workgroup {
+		t.Fatalf("FindAccount: want workgroup %q, got %q", acc.Workgroup, found.Workgroup)
+	}
+	if len(found.NTHash) == 0 {
+		t.Fatal("FindAccount: expected non-empty NTHash")
+	}
+
+	// FindAccount for unknown user returns zero value.
+	missing, err := db.FindAccount("nobody", acc.Workgroup)
+	if err != nil {
+		t.Fatalf("FindAccount missing: %v", err)
+	}
+	if missing.ID != 0 {
+		t.Fatal("FindAccount missing: expected zero value")
+	}
+
+	// GetAccountByID.
+	byID, err := db.GetAccountByID(found.ID)
+	if err != nil {
+		t.Fatalf("GetAccountByID: %v", err)
+	}
+	if byID.Username != acc.Username {
+		t.Fatalf("GetAccountByID: want %q, got %q", acc.Username, byID.Username)
+	}
+
+	// FindAccounts lists all accounts for the workgroup.
+	if err := db.AddAccount(Account{Username: "bob", Password: "pw", Workgroup: u.String()}); err != nil {
+		t.Fatalf("AddAccount bob: %v", err)
+	}
+	accs, err := db.FindAccounts(u.String())
+	if err != nil {
+		t.Fatalf("FindAccounts: %v", err)
+	}
+	if len(accs) != 2 {
+		t.Fatalf("FindAccounts: want 2, got %d", len(accs))
+	}
+
+	// RemoveAccount.
+	if err := db.RemoveAccount(acc.Username, acc.Workgroup); err != nil {
+		t.Fatalf("RemoveAccount: %v", err)
+	}
+	has, err = db.HasAccount(acc.Username, acc.Workgroup)
+	if err != nil {
+		t.Fatalf("HasAccount after remove: %v", err)
+	}
+	if has {
+		t.Fatal("HasAccount after remove: expected false")
+	}
+
+	// RemoveAccounts removes all remaining accounts.
+	if err := db.RemoveAccounts(u.String()); err != nil {
+		t.Fatalf("RemoveAccounts: %v", err)
+	}
+	accs, err = db.FindAccounts(u.String())
+	if err != nil {
+		t.Fatalf("FindAccounts after RemoveAccounts: %v", err)
+	}
+	if len(accs) != 0 {
+		t.Fatalf("FindAccounts after RemoveAccounts: want 0, got %d", len(accs))
+	}
+}
+
+func TestShares(t *testing.T) {
+	ctx := context.Background()
+	db := NewTestStore(t, ctx)
+	defer db.Close()
+
+	share := Share{
+		Name:         "mybucket",
+		Type:         "renterd",
+		ServerName:   "localhost",
+		Password:     "apipass",
+		Bucket:       "files",
+		Remark:       "test share",
+		DataShards:   10,
+		ParityShards: 4,
+	}
+
+	// RegisterShare.
+	if err := db.RegisterShare(share); err != nil {
+		t.Fatalf("RegisterShare: %v", err)
+	}
+
+	// GetShare.
+	got, err := db.GetShare(share.Name)
+	if err != nil {
+		t.Fatalf("GetShare: %v", err)
+	}
+	if got.Name != share.Name {
+		t.Fatalf("GetShare: want name %q, got %q", share.Name, got.Name)
+	}
+	if got.Type != share.Type {
+		t.Fatalf("GetShare: want type %q, got %q", share.Type, got.Type)
+	}
+	if got.DataShards != share.DataShards {
+		t.Fatalf("GetShare: want DataShards %d, got %d", share.DataShards, got.DataShards)
+	}
+	if got.ParityShards != share.ParityShards {
+		t.Fatalf("GetShare: want ParityShards %d, got %d", share.ParityShards, got.ParityShards)
+	}
+
+	// GetShare for unknown name returns zero value.
+	empty, err := db.GetShare("nosuchshare")
+	if err != nil {
+		t.Fatalf("GetShare missing: %v", err)
+	}
+	if empty.Name != "" {
+		t.Fatal("GetShare missing: expected empty share")
+	}
+
+	// UnregisterShare.
+	if err := db.UnregisterShare(share.Name); err != nil {
+		t.Fatalf("UnregisterShare: %v", err)
+	}
+	gone, err := db.GetShare(share.Name)
+	if err != nil {
+		t.Fatalf("GetShare after unregister: %v", err)
+	}
+	if gone.Name != "" {
+		t.Fatal("GetShare after unregister: expected empty share")
+	}
+}
+
+func TestGetShares(t *testing.T) {
+	ctx := context.Background()
+	db := NewTestStore(t, ctx)
+	defer db.Close()
+
+	u := uuid.New()
+	if err := db.AddWorkgroup(Workgroup{UUID: u}); err != nil {
+		t.Fatalf("AddWorkgroup: %v", err)
+	}
+	if err := db.AddAccount(Account{Username: "user1", Password: "pw", Workgroup: u.String()}); err != nil {
+		t.Fatalf("AddAccount: %v", err)
+	}
+	acc, err := db.FindAccount("user1", u.String())
+	if err != nil {
+		t.Fatalf("FindAccount: %v", err)
+	}
+
+	for _, name := range []string{"shareA", "shareB"} {
+		if err := db.RegisterShare(Share{Name: name, Type: "renterd", ServerName: "srv"}); err != nil {
+			t.Fatalf("RegisterShare %s: %v", name, err)
+		}
+	}
+
+	// Grant read access to shareA only.
+	if err := db.SetAccessRights(AccessRights{
+		ShareName:  "shareA",
+		AccountID:  acc.ID,
+		ReadAccess: true,
+	}); err != nil {
+		t.Fatalf("SetAccessRights: %v", err)
+	}
+
+	shares, err := db.GetShares(acc)
+	if err != nil {
+		t.Fatalf("GetShares: %v", err)
+	}
+	if len(shares) != 1 || shares[0].Name != "shareA" {
+		t.Fatalf("GetShares: want [shareA], got %v", shares)
+	}
+}
+
+func TestConnections(t *testing.T) {
+	ctx := context.Background()
+	db := NewTestStore(t, ctx)
+	defer db.Close()
+
+	u := uuid.New()
+	if err := db.AddWorkgroup(Workgroup{UUID: u}); err != nil {
+		t.Fatalf("AddWorkgroup: %v", err)
+	}
+	wg, err := db.FindWorkgroup(u)
+	if err != nil {
+		t.Fatalf("FindWorkgroup: %v", err)
+	}
+
+	if err := db.RegisterShare(Share{Name: "s1", Type: "renterd", ServerName: "srv"}); err != nil {
+		t.Fatalf("RegisterShare: %v", err)
+	}
+	share, err := db.GetShare("s1")
+	if err != nil {
+		t.Fatalf("GetShare: %v", err)
+	}
+
+	// Not connected initially.
+	connected, _, err := db.IsConnected(wg, share)
+	if err != nil {
+		t.Fatalf("IsConnected initial: %v", err)
+	}
+	if connected {
+		t.Fatal("IsConnected initial: expected false")
+	}
+
+	// AddConnection.
+	key := makeKey(t)
+	if err := db.AddConnection(wg, share, key); err != nil {
+		t.Fatalf("AddConnection: %v", err)
+	}
+
+	// IsConnected returns true and the correct key.
+	connected, gotKey, err := db.IsConnected(wg, share)
+	if err != nil {
+		t.Fatalf("IsConnected: %v", err)
+	}
+	if !connected {
+		t.Fatal("IsConnected: expected true")
+	}
+	if !bytes.Equal([]byte(gotKey), []byte(key)) {
+		t.Fatal("IsConnected: app key mismatch")
+	}
+
+	// AddConnection is idempotent (ON CONFLICT DO NOTHING); key must not change.
+	if err := db.AddConnection(wg, share, makeKey(t)); err != nil {
+		t.Fatalf("AddConnection idempotent: %v", err)
+	}
+	_, gotKey2, err := db.IsConnected(wg, share)
+	if err != nil {
+		t.Fatalf("IsConnected after idempotent add: %v", err)
+	}
+	if !bytes.Equal([]byte(gotKey2), []byte(key)) {
+		t.Fatal("AddConnection idempotent: key should not have changed")
+	}
+
+	// SetAppKey replaces the key.
+	newKey := makeKey(t)
+	if err := db.SetAppKey(wg, share, newKey); err != nil {
+		t.Fatalf("SetAppKey: %v", err)
+	}
+	_, gotKey, err = db.IsConnected(wg, share)
+	if err != nil {
+		t.Fatalf("IsConnected after SetAppKey: %v", err)
+	}
+	if !bytes.Equal([]byte(gotKey), []byte(newKey)) {
+		t.Fatal("IsConnected after SetAppKey: key mismatch")
+	}
+
+	// A different workgroup is not connected to the same share.
+	u2 := uuid.New()
+	if err := db.AddWorkgroup(Workgroup{UUID: u2}); err != nil {
+		t.Fatalf("AddWorkgroup u2: %v", err)
+	}
+	wg2, err := db.FindWorkgroup(u2)
+	if err != nil {
+		t.Fatalf("FindWorkgroup u2: %v", err)
+	}
+	connected, _, err = db.IsConnected(wg2, share)
+	if err != nil {
+		t.Fatalf("IsConnected wg2: %v", err)
+	}
+	if connected {
+		t.Fatal("IsConnected wg2: expected false")
+	}
+
+	// RemoveConnection.
+	if err := db.RemoveConnection(wg, share); err != nil {
+		t.Fatalf("RemoveConnection: %v", err)
+	}
+	connected, _, err = db.IsConnected(wg, share)
+	if err != nil {
+		t.Fatalf("IsConnected after remove: %v", err)
+	}
+	if connected {
+		t.Fatal("IsConnected after remove: expected false")
+	}
+}
+
+func TestPolicies(t *testing.T) {
+	ctx := context.Background()
+	db := NewTestStore(t, ctx)
+	defer db.Close()
+
+	u := uuid.New()
+	if err := db.AddWorkgroup(Workgroup{UUID: u}); err != nil {
+		t.Fatalf("AddWorkgroup: %v", err)
+	}
+	if err := db.AddAccount(Account{Username: "puser", Password: "pw", Workgroup: u.String()}); err != nil {
+		t.Fatalf("AddAccount: %v", err)
+	}
+	acc, err := db.FindAccount("puser", u.String())
+	if err != nil {
+		t.Fatalf("FindAccount: %v", err)
+	}
+	if err := db.RegisterShare(Share{Name: "pshare", Type: "renterd", ServerName: "srv"}); err != nil {
+		t.Fatalf("RegisterShare: %v", err)
+	}
+	share, err := db.GetShare("pshare")
+	if err != nil {
+		t.Fatalf("GetShare: %v", err)
+	}
+
+	// GetAccessRights returns zero value when no policy exists.
+	ar, err := db.GetAccessRights(share, acc)
+	if err != nil {
+		t.Fatalf("GetAccessRights pre-set: %v", err)
+	}
+	if ar.AccountID != 0 {
+		t.Fatal("GetAccessRights pre-set: expected zero value")
+	}
+
+	// SetAccessRights.
+	want := AccessRights{
+		ShareName:   share.Name,
+		AccountID:   acc.ID,
+		ReadAccess:  true,
+		WriteAccess: true,
+	}
+	if err := db.SetAccessRights(want); err != nil {
+		t.Fatalf("SetAccessRights: %v", err)
+	}
+	ar, err = db.GetAccessRights(share, acc)
+	if err != nil {
+		t.Fatalf("GetAccessRights: %v", err)
+	}
+	if !ar.ReadAccess || !ar.WriteAccess || ar.DeleteAccess || ar.ExecuteAccess {
+		t.Fatalf("GetAccessRights: unexpected flags %+v", ar)
+	}
+
+	// GetAccounts returns the account we just gave access.
+	ars, err := db.GetAccounts(share)
+	if err != nil {
+		t.Fatalf("GetAccounts: %v", err)
+	}
+	if len(ars) != 1 || ars[0].AccountID != acc.ID {
+		t.Fatalf("GetAccounts: got %v", ars)
+	}
+
+	// SetAccessRights acts as an upsert.
+	want.DeleteAccess = true
+	if err := db.SetAccessRights(want); err != nil {
+		t.Fatalf("SetAccessRights upsert: %v", err)
+	}
+	ar, err = db.GetAccessRights(share, acc)
+	if err != nil {
+		t.Fatalf("GetAccessRights after upsert: %v", err)
+	}
+	if !ar.DeleteAccess {
+		t.Fatal("GetAccessRights after upsert: expected DeleteAccess true")
+	}
+
+	// RemoveAccessRights.
+	if err := db.RemoveAccessRights(share, acc); err != nil {
+		t.Fatalf("RemoveAccessRights: %v", err)
+	}
+	ar, err = db.GetAccessRights(share, acc)
+	if err != nil {
+		t.Fatalf("GetAccessRights after remove: %v", err)
+	}
+	if ar.AccountID != 0 {
+		t.Fatal("GetAccessRights after remove: expected zero value")
+	}
+
+	// ClearAccessRights removes all policies for an account.
+	if err := db.SetAccessRights(want); err != nil {
+		t.Fatalf("SetAccessRights before clear: %v", err)
+	}
+	if err := db.ClearAccessRights(acc); err != nil {
+		t.Fatalf("ClearAccessRights: %v", err)
+	}
+	ars, err = db.GetAccounts(share)
+	if err != nil {
+		t.Fatalf("GetAccounts after clear: %v", err)
+	}
+	if len(ars) != 0 {
+		t.Fatalf("GetAccounts after clear: want 0, got %d", len(ars))
+	}
+}
+
+func TestFlagsFromAccessRights(t *testing.T) {
+	tests := []struct {
+		ar    AccessRights
+		flags uint32
+	}{
+		{AccessRights{}, 0},
+		{AccessRights{ReadAccess: true}, 0x80120089},
+		{AccessRights{WriteAccess: true}, 0x400c0116},
+		{AccessRights{DeleteAccess: true}, 0x00010040},
+		{AccessRights{ExecuteAccess: true}, 0x20000020},
+		{
+			AccessRights{ReadAccess: true, WriteAccess: true, DeleteAccess: true, ExecuteAccess: true},
+			0x80120089 | 0x400c0116 | 0x00010040 | 0x20000020 | 0x12000000,
+		},
+	}
+	for _, tc := range tests {
+		if got := FlagsFromAccessRights(tc.ar); got != tc.flags {
+			t.Errorf("FlagsFromAccessRights(%+v) = 0x%08x, want 0x%08x", tc.ar, got, tc.flags)
+		}
+	}
+}

--- a/stores/testutil.go
+++ b/stores/testutil.go
@@ -9,16 +9,23 @@ import (
 	"testing"
 
 	"github.com/jackc/pgx/v5"
+	"go.sia.tech/core/types"
 )
 
 type noopShares struct{}
 
-func (noopShares) RegisterShare(sh Share) error                       { return nil }
-func (noopShares) RemoveShare(sh Share) error                         { return nil }
-func (noopShares) UpdateAccessRights(sh Share, ar AccessRights) error { return nil }
-func (noopShares) RemoveAccess(acc Account)                           {}
+func (noopShares) RegisterShare(sh Share) error                                      { return nil }
+func (noopShares) RemoveShare(sh Share) error                                        { return nil }
+func (noopShares) UpdateAccessRights(sh Share, ar AccessRights) error                { return nil }
+func (noopShares) RemoveAccess(acc Account)                                          {}
+func (noopShares) AddConnection(_ Workgroup, _ Share, _ types.PrivateKey) error      { return nil }
+func (noopShares) RemoveConnection(_ Workgroup, _ Share) error                       { return nil }
 
 func NewTestStore(t *testing.T, ctx context.Context) *Database {
+	return NewTestStoreNamed(t, ctx, envOr(t, "TEST_DB_NAME", "sombrero_test"))
+}
+
+func NewTestStoreNamed(t *testing.T, ctx context.Context, dbName string) *Database {
 	t.Helper()
 
 	cfg := DatabaseConfig{
@@ -26,7 +33,7 @@ func NewTestStore(t *testing.T, ctx context.Context) *Database {
 		Port:     envOrInt(t, "TEST_DB_PORT", 5432),
 		User:     envOr(t, "TEST_DB_USER", "postgres"),
 		Password: os.Getenv("TEST_DB_PASSWORD"),
-		Database: envOr(t, "TEST_DB_NAME", "sombrero_test"),
+		Database: dbName,
 		SSLMode:  envOr(t, "TEST_DB_SSLMODE", "disable"),
 	}
 

--- a/stores/upload.go
+++ b/stores/upload.go
@@ -92,6 +92,7 @@ func (db *Database) CreateUpload(acc Account, share, path string) (uploadID stri
 					full_path,
 					size,
 					account,
+					workgroup,
 					temporary
 				)
 				SELECT
@@ -100,10 +101,12 @@ func (db *Database) CreateUpload(acc Account, share, path string) (uploadID stri
 					$5,
 					$4,
 					0,
-					$3,
+					c.id,
+					c.workgroup,
 					TRUE
 				FROM parent p
 				JOIN no_existing_upload n ON TRUE
+				CROSS JOIN caller c
 				RETURNING id
 			)
 			INSERT INTO uploads (upload_id, object_id)

--- a/stores/upload.go
+++ b/stores/upload.go
@@ -2,13 +2,13 @@ package stores
 
 import (
 	"context"
-	"crypto/rand"
 	"encoding/hex"
 	"errors"
 	"fmt"
 
 	"github.com/jackc/pgx/v5"
 	"go.sia.tech/core/types"
+	"lukechampine.com/frand"
 )
 
 // SlabSlice represents a slice of data within an uploaded slab.
@@ -45,7 +45,7 @@ func (db *Database) CreateUpload(acc Account, share, path string) (uploadID stri
 	}
 
 	id := make([]byte, 32)
-	rand.Read(id)
+	frand.Read(id)
 	uploadID = hex.EncodeToString(id)
 
 	err = db.txn(func(ctx context.Context, tx pgx.Tx) error {

--- a/stores/workgroups.go
+++ b/stores/workgroups.go
@@ -14,24 +14,29 @@ import (
 type Workgroup struct {
 	ID   int       `json:"id"`
 	UUID uuid.UUID `json:"uuid"`
+	Name string    `json:"name,omitempty"`
 }
 
 // GetWorkgroupByID tries to retrieve the workgroup by its ID.
 func (db *Database) GetWorkgroupByID(id int) (wg Workgroup, err error) {
 	err = db.txn(func(ctx context.Context, tx pgx.Tx) error {
 		const query = `
-			SELECT uuid
+			SELECT uuid, name
 			FROM workgroups
 			WHERE id = $1
 		`
 		var u uuid.UUID
-		err = tx.QueryRow(ctx, query, id).Scan(&u)
+		var name *string
+		err = tx.QueryRow(ctx, query, id).Scan(&u, &name)
 		if errors.Is(err, sql.ErrNoRows) {
 			return nil
 		} else if err != nil {
 			return fmt.Errorf("failed to retrieve workgroup: %w", err)
 		}
-		wg = Workgroup{id, u}
+		wg = Workgroup{ID: id, UUID: u}
+		if name != nil {
+			wg.Name = *name
+		}
 		return nil
 	})
 	return
@@ -41,18 +46,44 @@ func (db *Database) GetWorkgroupByID(id int) (wg Workgroup, err error) {
 func (db *Database) FindWorkgroup(u uuid.UUID) (wg Workgroup, err error) {
 	err = db.txn(func(ctx context.Context, tx pgx.Tx) error {
 		const query = `
-			SELECT id
+			SELECT id, name
 			FROM workgroups
 			WHERE uuid = $1
 		`
 		var id int
-		err = tx.QueryRow(ctx, query, u[:]).Scan(&id)
+		var name *string
+		err = tx.QueryRow(ctx, query, u[:]).Scan(&id, &name)
 		if errors.Is(err, sql.ErrNoRows) {
 			return nil
 		} else if err != nil {
 			return fmt.Errorf("failed to retrieve workgroup: %w", err)
 		}
-		wg = Workgroup{id, u}
+		wg = Workgroup{ID: id, UUID: u}
+		if name != nil {
+			wg.Name = *name
+		}
+		return nil
+	})
+	return
+}
+
+// FindWorkgroupByName tries to retrieve the workgroup by its name.
+func (db *Database) FindWorkgroupByName(name string) (wg Workgroup, err error) {
+	err = db.txn(func(ctx context.Context, tx pgx.Tx) error {
+		const query = `
+			SELECT id, uuid
+			FROM workgroups
+			WHERE name = $1
+		`
+		var id int
+		var u uuid.UUID
+		err = tx.QueryRow(ctx, query, name).Scan(&id, &u)
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil
+		} else if err != nil {
+			return fmt.Errorf("failed to retrieve workgroup: %w", err)
+		}
+		wg = Workgroup{ID: id, UUID: u, Name: name}
 		return nil
 	})
 	return
@@ -62,10 +93,14 @@ func (db *Database) FindWorkgroup(u uuid.UUID) (wg Workgroup, err error) {
 func (db *Database) AddWorkgroup(wg Workgroup) error {
 	return db.txn(func(ctx context.Context, tx pgx.Tx) error {
 		const query = `
-			INSERT INTO workgroups (uuid)
-			VALUES ($1)
+			INSERT INTO workgroups (uuid, name)
+			VALUES ($1, $2)
 		`
-		_, err := tx.Exec(ctx, query, wg.UUID[:])
+		var name any
+		if wg.Name != "" {
+			name = wg.Name
+		}
+		_, err := tx.Exec(ctx, query, wg.UUID[:], name)
 		if err != nil {
 			return fmt.Errorf("failed to add workgroup: %w", err)
 		}

--- a/stores/workgroups.go
+++ b/stores/workgroups.go
@@ -1,0 +1,89 @@
+package stores
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+)
+
+// Workgroup represents a workgroup that can contain multiple accounts.
+type Workgroup struct {
+	ID   int       `json:"id"`
+	UUID uuid.UUID `json:"uuid"`
+}
+
+// GetWorkgroupByID tries to retrieve the workgroup by its ID.
+func (db *Database) GetWorkgroupByID(id int) (wg Workgroup, err error) {
+	err = db.txn(func(ctx context.Context, tx pgx.Tx) error {
+		const query = `
+			SELECT uuid
+			FROM workgroups
+			WHERE id = $1
+		`
+		var u uuid.UUID
+		err = tx.QueryRow(ctx, query, id).Scan(&u)
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil
+		} else if err != nil {
+			return fmt.Errorf("failed to retrieve workgroup: %w", err)
+		}
+		wg = Workgroup{id, u}
+		return nil
+	})
+	return
+}
+
+// FindWorkgroup tries to retrieve the workgroup by its UUID.
+func (db *Database) FindWorkgroup(u uuid.UUID) (wg Workgroup, err error) {
+	err = db.txn(func(ctx context.Context, tx pgx.Tx) error {
+		const query = `
+			SELECT id
+			FROM workgroups
+			WHERE uuid = $1
+		`
+		var id int
+		err = tx.QueryRow(ctx, query, u[:]).Scan(&id)
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil
+		} else if err != nil {
+			return fmt.Errorf("failed to retrieve workgroup: %w", err)
+		}
+		wg = Workgroup{id, u}
+		return nil
+	})
+	return
+}
+
+// AddWorkgroup adds a new workgroup to the database.
+func (db *Database) AddWorkgroup(wg Workgroup) error {
+	return db.txn(func(ctx context.Context, tx pgx.Tx) error {
+		const query = `
+			INSERT INTO workgroups (uuid)
+			VALUES ($1)
+		`
+		_, err := tx.Exec(ctx, query, wg.UUID[:])
+		if err != nil {
+			return fmt.Errorf("failed to add workgroup: %w", err)
+		}
+		return nil
+	})
+}
+
+// RemoveWorkgroup removes the specified workgroup and all associated accounts from the database.
+func (db *Database) RemoveWorkgroup(wg Workgroup) error {
+	return db.txn(func(ctx context.Context, tx pgx.Tx) error {
+		const query = `
+			DELETE FROM workgroups
+			WHERE id = $1
+		`
+		_, err := tx.Exec(ctx, query, wg.ID)
+		if err != nil {
+			return fmt.Errorf("failed to remove workgroup: %w", err)
+		}
+		return nil
+	})
+}

--- a/tree.go
+++ b/tree.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"crypto/rand"
 	"encoding/binary"
 	"errors"
 	"strings"
@@ -9,6 +8,7 @@ import (
 	"time"
 
 	"github.com/mike76-dev/sombrero/smb2"
+	"lukechampine.com/frand"
 )
 
 var (
@@ -123,7 +123,7 @@ func (c *connection) newTreeConnect(ss *session, path string) (*treeConnect, err
 	}
 
 	var id [4]byte
-	rand.Read(id[:])
+	frand.Read(id[:])
 
 	tc := &treeConnect{
 		treeID:         binary.LittleEndian.Uint32(id[:]),

--- a/tree.go
+++ b/tree.go
@@ -3,10 +3,13 @@ package main
 import (
 	"encoding/binary"
 	"errors"
+	"log"
 	"strings"
 	"sync"
 	"time"
 
+	"github.com/google/uuid"
+	"github.com/mike76-dev/sombrero/client"
 	"github.com/mike76-dev/sombrero/smb2"
 	"lukechampine.com/frand"
 )
@@ -26,6 +29,12 @@ type treeConnect struct {
 	openCount     uint64
 	creationTime  time.Time
 	maximalAccess uint32
+
+	// Resolved at connect time from the share; for indexd these are per-workgroup.
+	client        client.Client
+	maxUploadSize uint64
+	createdAt     time.Time
+	volumeID      uint64
 
 	// When a request to create a file comes in, the client assumes that the file exists from then on.
 	// However, it's not possible to upload empty files to the Sia network, so we have to work around that.
@@ -113,6 +122,27 @@ func (c *connection) newTreeConnect(ss *session, path string) (*treeConnect, err
 			return nil, errTooManyUses
 		}
 		sh.mu.Unlock()
+
+		// For indexd, lazily restore a connection from the DB if not yet initialized.
+		if sh.backend == "indexd" {
+			sh.mu.Lock()
+			_, hasConn := sh.indexdConns[ss.workgroup]
+			sh.mu.Unlock()
+			if !hasConn {
+				if u, err := uuid.Parse(ss.workgroup); err == nil {
+					if wg, err := c.server.store.FindWorkgroup(u); err == nil && wg.ID != 0 {
+						if fullShare, err := c.server.store.GetShare(name); err == nil {
+							if connected, appKey, err := c.server.store.IsConnected(wg, fullShare); err == nil && connected {
+								if err := c.server.AddConnection(wg, fullShare, appKey); err != nil {
+									log.Printf("lazy indexd init %q/%q: %v", name, ss.workgroup, err)
+								}
+							}
+						}
+					}
+				}
+			}
+		}
+
 		access, exists = sh.fileSecurity[ss.workgroup+"/"+ss.userName]
 		if !exists {
 			return nil, errAccessDenied
@@ -120,6 +150,36 @@ func (c *connection) newTreeConnect(ss *session, path string) (*treeConnect, err
 		sh.mu.Lock()
 		sh.currentUses++
 		sh.mu.Unlock()
+	}
+
+	// Resolve the per-workgroup connection info for this tree connect.
+	var (
+		cl            client.Client
+		maxUploadSize uint64
+		createdAt     time.Time
+		volumeID      uint64
+	)
+	if sh.backend == "indexd" {
+		sh.mu.Lock()
+		conn, ok := sh.indexdConns[ss.workgroup]
+		if ok {
+			cl = conn.client
+			maxUploadSize = conn.maxUploadSize
+			createdAt = conn.createdAt
+			volumeID = conn.volumeID
+		}
+		sh.mu.Unlock()
+		if cl == nil {
+			sh.mu.Lock()
+			sh.currentUses--
+			sh.mu.Unlock()
+			return nil, errShareUnavailable
+		}
+	} else {
+		cl = sh.client
+		maxUploadSize = sh.maxUploadSize
+		createdAt = sh.createdAt
+		volumeID = sh.volumeID
 	}
 
 	var id [4]byte
@@ -131,6 +191,10 @@ func (c *connection) newTreeConnect(ss *session, path string) (*treeConnect, err
 		share:          sh,
 		creationTime:   time.Now(),
 		maximalAccess:  access,
+		client:         cl,
+		maxUploadSize:  maxUploadSize,
+		createdAt:      createdAt,
+		volumeID:       volumeID,
 		persistedOpens: make(map[string]*open),
 	}
 


### PR DESCRIPTION
This PR enables using multiple `indexd` accounts per share, each connected to a separate workgroup.